### PR TITLE
Reintroduce completion blocks

### DIFF
--- a/OktaSdk.podspec
+++ b/OktaSdk.podspec
@@ -1,24 +1,15 @@
 Pod::Spec.new do |s|
-    s.name             = 'OktaSdk'
-    s.version          = "0.1.0"
-    s.summary          = "Okta Management SDK for Swift"
-    s.description      = <<-DESC
-Provides APIs for interacting with, and making changes on, an Okta organization.
-                         DESC
-    s.platforms = {
-        :ios     => "15.0",
-        :tvos    => "15.0",
-        :osx     => "12.0"
-    }
-    s.ios.deployment_target     = "15.0"
-    s.tvos.deployment_target    = "15.0"
-    s.osx.deployment_target     = "12.0"
-
-    s.homepage      = "https://github.com/okta/okta-sdk-swift"
-    s.license       = { :type => "APACHE2", :file => "LICENSE" }
-    s.authors       = { "Okta Developers" => "developer@okta.com"}
-    s.source        = { :git => "https://github.com/okta/okta-sdk-swift.git", :tag => s.version.to_s }
-    s.source_files  = "Sources/OktaSdk/**/*.swift"
-    s.swift_version = "5.5"
-    s.dependency 'AnyCodable-FlightSchool', '~> 0.4.0'
+  s.name = 'OktaSdk'
+  s.ios.deployment_target = '9.0'
+  s.osx.deployment_target = '10.11'
+  s.tvos.deployment_target = '9.0'
+  s.watchos.deployment_target = '3.0'
+  s.version = '3.0.0'
+  s.source = { :git => 'git@github.com:OpenAPITools/openapi-generator.git', :tag => 'v3.0.0' }
+  s.authors = 'OpenAPI Generator'
+  s.license = 'Proprietary'
+  s.homepage = 'https://github.com/OpenAPITools/openapi-generator'
+  s.summary = 'OktaSdk Swift SDK'
+  s.source_files = 'Sources/OktaSdk/ManagementAPI//**/*.swift'
+  s.dependency 'AnyCodable-FlightSchool', '~> 0.4.0'
 end

--- a/Package.swift
+++ b/Package.swift
@@ -5,9 +5,9 @@ import PackageDescription
 let package = Package(
     name: "OktaSdk",
     platforms: [
-        .iOS(.v15),
+        .iOS(.v10),
         .macOS(.v12),
-        .tvOS(.v15)
+        .tvOS(.v10)
     ],
     products: [
         .library(

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ To get started, you will need:
 
 - An Okta account, called an _organization_ (sign up for a free [developer organization][dev-okta-signup] if you need one).
 - An [API token][api-token-docs].
-- Xcode targeting iOS 15 or above, tvOS 15 or above, or macOS 12 or above.
+- Xcode targeting iOS 10 or above, tvOS 10 or above, or macOS 12 or above.
 
 ### Swift Package Manager
 
@@ -82,7 +82,7 @@ Once you initialize a `client`, you can call methods to make requests to the Okt
 
 ### Making API calls
 
-The client provides async methods using Swift Concurrency for each API call.
+The client provides completion handler-based methods, as well as async methods using Swift Concurrency, for each API call.
 
 Most methods are grouped by the API endpoint they belong to. For example, methods that call the [Users API][users-api-docs] are organized under the User resource client `client.user.*`.
 

--- a/Sources/OktaSdk/ManagementAPI/OktaSdk/AgentPoolsAPI.swift
+++ b/Sources/OktaSdk/ManagementAPI/OktaSdk/AgentPoolsAPI.swift
@@ -39,6 +39,24 @@ public extension OktaClient {
         }
 
         /**
+         Activate an Agent Pool update
+         
+         - parameter poolId: (path) Id of the agent pool for which the settings will apply 
+         - parameter updateId: (path) Id of the update 
+         - parameter completion: Completion block
+         */
+        public func activateAgentPoolsUpdate(poolId: String, updateId: String, completion: @escaping (Result<OktaResponse<AgentPoolUpdate>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/agentPools/{poolId}/updates/{updateId}/activate".expanded(using: [
+                        "poolId": poolId, 
+                        "updateId": updateId
+                    ]), method: "POST"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Create an Agent Pool update
          
          - parameter poolId: (path) Id of the agent pool for which the settings will apply 
@@ -48,6 +66,23 @@ public extension OktaClient {
             try await send(try requestWithBody(to: "/api/v1/agentPools/{poolId}/updates".expanded(using: [
                     "poolId": poolId
                 ]), method: "POST", body: agentPoolUpdate))
+        }
+
+        /**
+         Create an Agent Pool update
+         
+         - parameter poolId: (path) Id of the agent pool for which the settings will apply 
+         - parameter agentPoolUpdate: (body)  
+         - parameter completion: Completion block
+         */
+        public func createAgentPoolsUpdate(poolId: String, agentPoolUpdate: AgentPoolUpdate, completion: @escaping (Result<OktaResponse<AgentPoolUpdate>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/agentPools/{poolId}/updates".expanded(using: [
+                        "poolId": poolId
+                    ]), method: "POST", body: agentPoolUpdate), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -64,6 +99,24 @@ public extension OktaClient {
         }
 
         /**
+         Deactivate an Agent Pool update
+         
+         - parameter poolId: (path) Id of the agent pool for which the settings will apply 
+         - parameter updateId: (path) Id of the update 
+         - parameter completion: Completion block
+         */
+        public func deactivateAgentPoolsUpdate(poolId: String, updateId: String, completion: @escaping (Result<OktaResponse<AgentPoolUpdate>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/agentPools/{poolId}/updates/{updateId}/deactivate".expanded(using: [
+                        "poolId": poolId, 
+                        "updateId": updateId
+                    ]), method: "POST"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Delete an Agent Pool update
          
          - parameter poolId: (path) Id of the agent pool for which the settings will apply 
@@ -75,6 +128,24 @@ public extension OktaClient {
                     "poolId": poolId, 
                     "updateId": updateId
                 ]), method: "DELETE"))
+        }
+
+        /**
+         Delete an Agent Pool update
+         
+         - parameter poolId: (path) Id of the agent pool for which the settings will apply 
+         - parameter updateId: (path) Id of the update 
+         - parameter completion: Completion block
+         */
+        public func deleteAgentPoolsUpdate(poolId: String, updateId: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/agentPools/{poolId}/updates/{updateId}".expanded(using: [
+                        "poolId": poolId, 
+                        "updateId": updateId
+                    ]), method: "DELETE"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -93,6 +164,26 @@ public extension OktaClient {
         }
 
         /**
+         List all Agent Pools
+         
+         - parameter limitPerPoolType: (query) Maximum number of AgentPools being returned (optional, default to 5)
+         - parameter poolType: (query) Agent type to search for (optional)
+         - parameter after: (query) The cursor to use for pagination. It is an opaque string that specifies your current location in the list and is obtained from the &#x60;Link&#x60; response header. See [Pagination](https://developer.okta.com/docs/reference/core-okta-api/#pagination) for more information. (optional)
+         - parameter completion: Completion block
+         */
+        public func getAgentPools(limitPerPoolType: Int? = nil, poolType: AgentType? = nil, after: String? = nil, completion: @escaping (Result<OktaResponse<[AgentPool]>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/agentPools", method: "GET", query: [
+                        "limitPerPoolType": limitPerPoolType, 
+                        "poolType": poolType, 
+                        "after": after
+                    ]), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Retrieve an Agent Pool update by id
          
          - parameter poolId: (path) Id of the agent pool for which the settings will apply 
@@ -106,6 +197,24 @@ public extension OktaClient {
         }
 
         /**
+         Retrieve an Agent Pool update by id
+         
+         - parameter poolId: (path) Id of the agent pool for which the settings will apply 
+         - parameter updateId: (path) Id of the update 
+         - parameter completion: Completion block
+         */
+        public func getAgentPoolsUpdateInstance(poolId: String, updateId: String, completion: @escaping (Result<OktaResponse<AgentPoolUpdate>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/agentPools/{poolId}/updates/{updateId}".expanded(using: [
+                        "poolId": poolId, 
+                        "updateId": updateId
+                    ]), method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Retrieve an Agent Pool update's settings
          
          - parameter poolId: (path) Id of the agent pool for which the settings will apply 
@@ -114,6 +223,22 @@ public extension OktaClient {
             try await send(try request(to: "/api/v1/agentPools/{poolId}/updates/settings".expanded(using: [
                     "poolId": poolId
                 ]), method: "GET"))
+        }
+
+        /**
+         Retrieve an Agent Pool update's settings
+         
+         - parameter poolId: (path) Id of the agent pool for which the settings will apply 
+         - parameter completion: Completion block
+         */
+        public func getAgentPoolsUpdateSettings(poolId: String, completion: @escaping (Result<OktaResponse<AgentPoolUpdateSetting>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/agentPools/{poolId}/updates/settings".expanded(using: [
+                        "poolId": poolId
+                    ]), method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -131,6 +256,25 @@ public extension OktaClient {
         }
 
         /**
+         List all Agent Pool updates
+         
+         - parameter poolId: (path) Id of the agent pool for which the settings will apply 
+         - parameter scheduled: (query) Scope the list only to scheduled or ad-hoc updates. If the parameter is not provided we will return the whole list of updates. (optional)
+         - parameter completion: Completion block
+         */
+        public func getAgentPoolsUpdates(poolId: String, scheduled: Bool? = nil, completion: @escaping (Result<OktaResponse<[AgentPoolUpdate]>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/agentPools/{poolId}/updates".expanded(using: [
+                        "poolId": poolId
+                    ]), method: "GET", query: [
+                        "scheduled": scheduled
+                    ]), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Pause an Agent Pool update
          
          - parameter poolId: (path) Id of the agent pool for which the settings will apply 
@@ -141,6 +285,24 @@ public extension OktaClient {
                     "poolId": poolId, 
                     "updateId": updateId
                 ]), method: "POST"))
+        }
+
+        /**
+         Pause an Agent Pool update
+         
+         - parameter poolId: (path) Id of the agent pool for which the settings will apply 
+         - parameter updateId: (path) Id of the update 
+         - parameter completion: Completion block
+         */
+        public func pauseAgentPoolsUpdate(poolId: String, updateId: String, completion: @escaping (Result<OktaResponse<AgentPoolUpdate>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/agentPools/{poolId}/updates/{updateId}/pause".expanded(using: [
+                        "poolId": poolId, 
+                        "updateId": updateId
+                    ]), method: "POST"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -157,6 +319,24 @@ public extension OktaClient {
         }
 
         /**
+         Resume an Agent Pool update
+         
+         - parameter poolId: (path) Id of the agent pool for which the settings will apply 
+         - parameter updateId: (path) Id of the update 
+         - parameter completion: Completion block
+         */
+        public func resumeAgentPoolsUpdate(poolId: String, updateId: String, completion: @escaping (Result<OktaResponse<AgentPoolUpdate>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/agentPools/{poolId}/updates/{updateId}/resume".expanded(using: [
+                        "poolId": poolId, 
+                        "updateId": updateId
+                    ]), method: "POST"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Retry an Agent Pool update
          
          - parameter poolId: (path) Id of the agent pool for which the settings will apply 
@@ -170,6 +350,24 @@ public extension OktaClient {
         }
 
         /**
+         Retry an Agent Pool update
+         
+         - parameter poolId: (path) Id of the agent pool for which the settings will apply 
+         - parameter updateId: (path) Id of the update 
+         - parameter completion: Completion block
+         */
+        public func retryAgentPoolsUpdate(poolId: String, updateId: String, completion: @escaping (Result<OktaResponse<AgentPoolUpdate>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/agentPools/{poolId}/updates/{updateId}/retry".expanded(using: [
+                        "poolId": poolId, 
+                        "updateId": updateId
+                    ]), method: "POST"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Update an Agent pool update settings
          
          - parameter poolId: (path) Id of the agent pool for which the settings will apply 
@@ -179,6 +377,23 @@ public extension OktaClient {
             try await send(try requestWithBody(to: "/api/v1/agentPools/{poolId}/updates/settings".expanded(using: [
                     "poolId": poolId
                 ]), method: "POST", body: agentPoolUpdateSetting))
+        }
+
+        /**
+         Update an Agent pool update settings
+         
+         - parameter poolId: (path) Id of the agent pool for which the settings will apply 
+         - parameter agentPoolUpdateSetting: (body)  
+         - parameter completion: Completion block
+         */
+        public func setAgentPoolsUpdateSettings(poolId: String, agentPoolUpdateSetting: AgentPoolUpdateSetting, completion: @escaping (Result<OktaResponse<AgentPoolUpdateSetting>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/agentPools/{poolId}/updates/settings".expanded(using: [
+                        "poolId": poolId
+                    ]), method: "POST", body: agentPoolUpdateSetting), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -195,6 +410,24 @@ public extension OktaClient {
         }
 
         /**
+         Stop an Agent Pool update
+         
+         - parameter poolId: (path) Id of the agent pool for which the settings will apply 
+         - parameter updateId: (path) Id of the update 
+         - parameter completion: Completion block
+         */
+        public func stopAgentPoolsUpdate(poolId: String, updateId: String, completion: @escaping (Result<OktaResponse<AgentPoolUpdate>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/agentPools/{poolId}/updates/{updateId}/stop".expanded(using: [
+                        "poolId": poolId, 
+                        "updateId": updateId
+                    ]), method: "POST"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Update an Agent Pool update by id
          
          - parameter poolId: (path) Id of the agent pool for which the settings will apply 
@@ -206,6 +439,25 @@ public extension OktaClient {
                     "poolId": poolId, 
                     "updateId": updateId
                 ]), method: "POST", body: agentPoolUpdate))
+        }
+
+        /**
+         Update an Agent Pool update by id
+         
+         - parameter poolId: (path) Id of the agent pool for which the settings will apply 
+         - parameter updateId: (path) Id of the update 
+         - parameter agentPoolUpdate: (body)  
+         - parameter completion: Completion block
+         */
+        public func updateAgentPoolsUpdate(poolId: String, updateId: String, agentPoolUpdate: AgentPoolUpdate, completion: @escaping (Result<OktaResponse<AgentPoolUpdate>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/agentPools/{poolId}/updates/{updateId}".expanded(using: [
+                        "poolId": poolId, 
+                        "updateId": updateId
+                    ]), method: "POST", body: agentPoolUpdate), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
     }

--- a/Sources/OktaSdk/ManagementAPI/OktaSdk/ApiTokenAPI.swift
+++ b/Sources/OktaSdk/ManagementAPI/OktaSdk/ApiTokenAPI.swift
@@ -37,6 +37,22 @@ public extension OktaClient {
         }
 
         /**
+         Retrieve an API Token's Metadata
+         
+         - parameter apiTokenId: (path) id of the API Token 
+         - parameter completion: Completion block
+         */
+        public func getApiToken(apiTokenId: String, completion: @escaping (Result<OktaResponse<ApiToken>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/api-tokens/{apiTokenId}".expanded(using: [
+                        "apiTokenId": apiTokenId
+                    ]), method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          List all API Token Metadata
          
          - parameter after: (query) The cursor to use for pagination. It is an opaque string that specifies your current location in the list and is obtained from the &#x60;Link&#x60; response header. See [Pagination](https://developer.okta.com/docs/reference/core-okta-api/#pagination) for more information. (optional)
@@ -52,6 +68,26 @@ public extension OktaClient {
         }
 
         /**
+         List all API Token Metadata
+         
+         - parameter after: (query) The cursor to use for pagination. It is an opaque string that specifies your current location in the list and is obtained from the &#x60;Link&#x60; response header. See [Pagination](https://developer.okta.com/docs/reference/core-okta-api/#pagination) for more information. (optional)
+         - parameter limit: (query) A limit on the number of objects to return. (optional, default to 20)
+         - parameter q: (query) Finds a token that matches the name or clientName. (optional)
+         - parameter completion: Completion block
+         */
+        public func listApiTokens(after: String? = nil, limit: Int? = nil, q: String? = nil, completion: @escaping (Result<OktaResponse<[ApiToken]>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/api-tokens", method: "GET", query: [
+                        "after": after, 
+                        "limit": limit, 
+                        "q": q
+                    ]), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Revoke an API Token
          
          - parameter apiTokenId: (path) id of the API Token 
@@ -64,12 +100,41 @@ public extension OktaClient {
         }
 
         /**
+         Revoke an API Token
+         
+         - parameter apiTokenId: (path) id of the API Token 
+         - parameter completion: Completion block
+         */
+        public func revokeApiToken(apiTokenId: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/api-tokens/{apiTokenId}".expanded(using: [
+                        "apiTokenId": apiTokenId
+                    ]), method: "DELETE"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Revoke the Current API Token
          
          */
         @discardableResult
         public func revokeCurrentApiToken() async throws -> OktaResponse<Empty> {
             try await send(try request(to: "/api/v1/api-tokens/current", method: "DELETE"))
+        }
+
+        /**
+         Revoke the Current API Token
+         
+         - parameter completion: Completion block
+         */
+        public func revokeCurrentApiToken(completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/api-tokens/current", method: "DELETE"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
     }

--- a/Sources/OktaSdk/ManagementAPI/OktaSdk/ApplicationAPI.swift
+++ b/Sources/OktaSdk/ManagementAPI/OktaSdk/ApplicationAPI.swift
@@ -38,6 +38,22 @@ public extension OktaClient {
         }
 
         /**
+         Activate an Application
+         
+         - parameter appId: (path)  
+         - parameter completion: Completion block
+         */
+        public func activateApplication(appId: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/apps/{appId}/lifecycle/activate".expanded(using: [
+                        "appId": appId
+                    ]), method: "POST"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Activate the default Provisioning Connection
          
          - parameter appId: (path)  
@@ -50,6 +66,22 @@ public extension OktaClient {
         }
 
         /**
+         Activate the default Provisioning Connection
+         
+         - parameter appId: (path)  
+         - parameter completion: Completion block
+         */
+        public func activateDefaultProvisioningConnectionForApplication(appId: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/apps/{appId}/connections/default/lifecycle/activate".expanded(using: [
+                        "appId": appId
+                    ]), method: "POST"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Assign a User
          
          - parameter appId: (path)  
@@ -59,6 +91,23 @@ public extension OktaClient {
             try await send(try requestWithBody(to: "/api/v1/apps/{appId}/users".expanded(using: [
                     "appId": appId
                 ]), method: "POST", body: appUser))
+        }
+
+        /**
+         Assign a User
+         
+         - parameter appId: (path)  
+         - parameter appUser: (body)  
+         - parameter completion: Completion block
+         */
+        public func assignUserToApplication(appId: String, appUser: AppUser, completion: @escaping (Result<OktaResponse<AppUser>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/apps/{appId}/users".expanded(using: [
+                        "appId": appId
+                    ]), method: "POST", body: appUser), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -78,6 +127,27 @@ public extension OktaClient {
         }
 
         /**
+         Clone a Key Credential
+         
+         - parameter appId: (path)  
+         - parameter keyId: (path)  
+         - parameter targetAid: (query) Unique key of the target Application 
+         - parameter completion: Completion block
+         */
+        public func cloneApplicationKey(appId: String, keyId: String, targetAid: String, completion: @escaping (Result<OktaResponse<JsonWebKey>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/apps/{appId}/credentials/keys/{keyId}/clone".expanded(using: [
+                        "appId": appId, 
+                        "keyId": keyId
+                    ]), method: "POST", query: [
+                        "targetAid": targetAid
+                    ]), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Create an Application
          
          - parameter application: (body)  
@@ -90,6 +160,26 @@ public extension OktaClient {
                 ], headers: [
                     "oktaAccessGatewayAgent": oktaAccessGatewayAgent?.stringValue
                 ], body: application))
+        }
+
+        /**
+         Create an Application
+         
+         - parameter application: (body)  
+         - parameter activate: (query) Executes activation lifecycle operation when creating the app (optional, default to true)
+         - parameter oktaAccessGatewayAgent: (header)  (optional)
+         - parameter completion: Completion block
+         */
+        public func createApplication(application: Application, activate: Bool? = nil, oktaAccessGatewayAgent: String? = nil, completion: @escaping (Result<OktaResponse<Application>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/apps", method: "POST", query: [
+                        "activate": activate
+                    ], headers: [
+                        "oktaAccessGatewayAgent": oktaAccessGatewayAgent?.stringValue
+                    ], body: application), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -107,6 +197,25 @@ public extension OktaClient {
         }
 
         /**
+         Assign a Group
+         
+         - parameter appId: (path)  
+         - parameter groupId: (path)  
+         - parameter applicationGroupAssignment: (body)  (optional)
+         - parameter completion: Completion block
+         */
+        public func createApplicationGroupAssignment(appId: String, groupId: String, applicationGroupAssignment: ApplicationGroupAssignment? = nil, completion: @escaping (Result<OktaResponse<ApplicationGroupAssignment>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/apps/{appId}/groups/{groupId}".expanded(using: [
+                        "appId": appId, 
+                        "groupId": groupId
+                    ]), method: "PUT", body: applicationGroupAssignment), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Deactivate an Application
          
          - parameter appId: (path)  
@@ -116,6 +225,22 @@ public extension OktaClient {
             try await send(try request(to: "/api/v1/apps/{appId}/lifecycle/deactivate".expanded(using: [
                     "appId": appId
                 ]), method: "POST"))
+        }
+
+        /**
+         Deactivate an Application
+         
+         - parameter appId: (path)  
+         - parameter completion: Completion block
+         */
+        public func deactivateApplication(appId: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/apps/{appId}/lifecycle/deactivate".expanded(using: [
+                        "appId": appId
+                    ]), method: "POST"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -131,6 +256,22 @@ public extension OktaClient {
         }
 
         /**
+         Deactivate the default Provisioning Connection for an Application
+         
+         - parameter appId: (path)  
+         - parameter completion: Completion block
+         */
+        public func deactivateDefaultProvisioningConnectionForApplication(appId: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/apps/{appId}/connections/default/lifecycle/deactivate".expanded(using: [
+                        "appId": appId
+                    ]), method: "POST"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Delete an Application
          
          - parameter appId: (path)  
@@ -140,6 +281,22 @@ public extension OktaClient {
             try await send(try request(to: "/api/v1/apps/{appId}".expanded(using: [
                     "appId": appId
                 ]), method: "DELETE"))
+        }
+
+        /**
+         Delete an Application
+         
+         - parameter appId: (path)  
+         - parameter completion: Completion block
+         */
+        public func deleteApplication(appId: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/apps/{appId}".expanded(using: [
+                        "appId": appId
+                    ]), method: "DELETE"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -154,6 +311,24 @@ public extension OktaClient {
                     "appId": appId, 
                     "groupId": groupId
                 ]), method: "DELETE"))
+        }
+
+        /**
+         Unassign a Group
+         
+         - parameter appId: (path)  
+         - parameter groupId: (path)  
+         - parameter completion: Completion block
+         */
+        public func deleteApplicationGroupAssignment(appId: String, groupId: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/apps/{appId}/groups/{groupId}".expanded(using: [
+                        "appId": appId, 
+                        "groupId": groupId
+                    ]), method: "DELETE"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -174,6 +349,27 @@ public extension OktaClient {
         }
 
         /**
+         Unassign a User
+         
+         - parameter appId: (path)  
+         - parameter userId: (path)  
+         - parameter sendEmail: (query)  (optional, default to false)
+         - parameter completion: Completion block
+         */
+        public func deleteApplicationUser(appId: String, userId: String, sendEmail: Bool? = nil, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/apps/{appId}/users/{userId}".expanded(using: [
+                        "appId": appId, 
+                        "userId": userId
+                    ]), method: "DELETE", query: [
+                        "sendEmail": sendEmail
+                    ]), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Generate a Key Credential
          
          - parameter appId: (path)  
@@ -185,6 +381,25 @@ public extension OktaClient {
                 ]), method: "POST", query: [
                     "validityYears": validityYears
                 ]))
+        }
+
+        /**
+         Generate a Key Credential
+         
+         - parameter appId: (path)  
+         - parameter validityYears: (query)  (optional)
+         - parameter completion: Completion block
+         */
+        public func generateApplicationKey(appId: String, validityYears: Int? = nil, completion: @escaping (Result<OktaResponse<JsonWebKey>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/apps/{appId}/credentials/keys/generate".expanded(using: [
+                        "appId": appId
+                    ]), method: "POST", query: [
+                        "validityYears": validityYears
+                    ]), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -200,6 +415,23 @@ public extension OktaClient {
         }
 
         /**
+         Generate a Certificate Signing Request
+         
+         - parameter appId: (path)  
+         - parameter metadata: (body)  
+         - parameter completion: Completion block
+         */
+        public func generateCsrForApplication(appId: String, metadata: CsrMetadata, completion: @escaping (Result<OktaResponse<Csr>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/apps/{appId}/credentials/csrs".expanded(using: [
+                        "appId": appId
+                    ]), method: "POST", body: metadata), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Retrieve an Application
          
          - parameter appId: (path)  
@@ -211,6 +443,25 @@ public extension OktaClient {
                 ]), method: "GET", query: [
                     "expand": expand
                 ]))
+        }
+
+        /**
+         Retrieve an Application
+         
+         - parameter appId: (path)  
+         - parameter expand: (query)  (optional)
+         - parameter completion: Completion block
+         */
+        public func getApplication(appId: String, expand: String? = nil, completion: @escaping (Result<OktaResponse<Application>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/apps/{appId}".expanded(using: [
+                        "appId": appId
+                    ]), method: "GET", query: [
+                        "expand": expand
+                    ]), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -230,6 +481,27 @@ public extension OktaClient {
         }
 
         /**
+         Retrieve an Assigned Group
+         
+         - parameter appId: (path)  
+         - parameter groupId: (path)  
+         - parameter expand: (query)  (optional)
+         - parameter completion: Completion block
+         */
+        public func getApplicationGroupAssignment(appId: String, groupId: String, expand: String? = nil, completion: @escaping (Result<OktaResponse<ApplicationGroupAssignment>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/apps/{appId}/groups/{groupId}".expanded(using: [
+                        "appId": appId, 
+                        "groupId": groupId
+                    ]), method: "GET", query: [
+                        "expand": expand
+                    ]), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Retrieve a Key Credential
          
          - parameter appId: (path)  
@@ -240,6 +512,24 @@ public extension OktaClient {
                     "appId": appId, 
                     "keyId": keyId
                 ]), method: "GET"))
+        }
+
+        /**
+         Retrieve a Key Credential
+         
+         - parameter appId: (path)  
+         - parameter keyId: (path)  
+         - parameter completion: Completion block
+         */
+        public func getApplicationKey(appId: String, keyId: String, completion: @escaping (Result<OktaResponse<JsonWebKey>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/apps/{appId}/credentials/keys/{keyId}".expanded(using: [
+                        "appId": appId, 
+                        "keyId": keyId
+                    ]), method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -259,6 +549,27 @@ public extension OktaClient {
         }
 
         /**
+         Retrieve an Assigned User
+         
+         - parameter appId: (path)  
+         - parameter userId: (path)  
+         - parameter expand: (query)  (optional)
+         - parameter completion: Completion block
+         */
+        public func getApplicationUser(appId: String, userId: String, expand: String? = nil, completion: @escaping (Result<OktaResponse<AppUser>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/apps/{appId}/users/{userId}".expanded(using: [
+                        "appId": appId, 
+                        "userId": userId
+                    ]), method: "GET", query: [
+                        "expand": expand
+                    ]), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Retrieve a Certificate Signing Request
          
          - parameter appId: (path)  
@@ -269,6 +580,24 @@ public extension OktaClient {
                     "appId": appId, 
                     "csrId": csrId
                 ]), method: "GET"))
+        }
+
+        /**
+         Retrieve a Certificate Signing Request
+         
+         - parameter appId: (path)  
+         - parameter csrId: (path)  
+         - parameter completion: Completion block
+         */
+        public func getCsrForApplication(appId: String, csrId: String, completion: @escaping (Result<OktaResponse<Csr>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/apps/{appId}/credentials/csrs/{csrId}".expanded(using: [
+                        "appId": appId, 
+                        "csrId": csrId
+                    ]), method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -283,6 +612,22 @@ public extension OktaClient {
         }
 
         /**
+         Retrieve the default Provisioning Connection
+         
+         - parameter appId: (path)  
+         - parameter completion: Completion block
+         */
+        public func getDefaultProvisioningConnectionForApplication(appId: String, completion: @escaping (Result<OktaResponse<ProvisioningConnection>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/apps/{appId}/connections/default".expanded(using: [
+                        "appId": appId
+                    ]), method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Retrieve a Feature
          
          - parameter appId: (path)  
@@ -293,6 +638,24 @@ public extension OktaClient {
                     "appId": appId, 
                     "name": name
                 ]), method: "GET"))
+        }
+
+        /**
+         Retrieve a Feature
+         
+         - parameter appId: (path)  
+         - parameter name: (path)  
+         - parameter completion: Completion block
+         */
+        public func getFeatureForApplication(appId: String, name: String, completion: @escaping (Result<OktaResponse<ApplicationFeature>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/apps/{appId}/features/{name}".expanded(using: [
+                        "appId": appId, 
+                        "name": name
+                    ]), method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -312,6 +675,27 @@ public extension OktaClient {
         }
 
         /**
+         Retrieve an OAuth 2.0 Token
+         
+         - parameter appId: (path)  
+         - parameter tokenId: (path)  
+         - parameter expand: (query)  (optional)
+         - parameter completion: Completion block
+         */
+        public func getOAuth2TokenForApplication(appId: String, tokenId: String, expand: String? = nil, completion: @escaping (Result<OktaResponse<OAuth2Token>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/apps/{appId}/tokens/{tokenId}".expanded(using: [
+                        "appId": appId, 
+                        "tokenId": tokenId
+                    ]), method: "GET", query: [
+                        "expand": expand
+                    ]), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Retrieve a Scope Consent Grant
          
          - parameter appId: (path)  
@@ -328,6 +712,27 @@ public extension OktaClient {
         }
 
         /**
+         Retrieve a Scope Consent Grant
+         
+         - parameter appId: (path)  
+         - parameter grantId: (path)  
+         - parameter expand: (query)  (optional)
+         - parameter completion: Completion block
+         */
+        public func getScopeConsentGrant(appId: String, grantId: String, expand: String? = nil, completion: @escaping (Result<OktaResponse<OAuth2ScopeConsentGrant>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/apps/{appId}/grants/{grantId}".expanded(using: [
+                        "appId": appId, 
+                        "grantId": grantId
+                    ]), method: "GET", query: [
+                        "expand": expand
+                    ]), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Grant Consent to Scope
          
          - parameter appId: (path)  
@@ -337,6 +742,23 @@ public extension OktaClient {
             try await send(try requestWithBody(to: "/api/v1/apps/{appId}/grants".expanded(using: [
                     "appId": appId
                 ]), method: "POST", body: oAuth2ScopeConsentGrant))
+        }
+
+        /**
+         Grant Consent to Scope
+         
+         - parameter appId: (path)  
+         - parameter oAuth2ScopeConsentGrant: (body)  
+         - parameter completion: Completion block
+         */
+        public func grantConsentToScope(appId: String, oAuth2ScopeConsentGrant: OAuth2ScopeConsentGrant, completion: @escaping (Result<OktaResponse<OAuth2ScopeConsentGrant>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/apps/{appId}/grants".expanded(using: [
+                        "appId": appId
+                    ]), method: "POST", body: oAuth2ScopeConsentGrant), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -360,6 +782,31 @@ public extension OktaClient {
         }
 
         /**
+         List all Assigned Groups
+         
+         - parameter appId: (path)  
+         - parameter q: (query)  (optional)
+         - parameter after: (query) Specifies the pagination cursor for the next page of assignments (optional)
+         - parameter limit: (query) Specifies the number of results for a page (optional, default to -1)
+         - parameter expand: (query)  (optional)
+         - parameter completion: Completion block
+         */
+        public func listApplicationGroupAssignments(appId: String, q: String? = nil, after: String? = nil, limit: Int? = nil, expand: String? = nil, completion: @escaping (Result<OktaResponse<[ApplicationGroupAssignment]>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/apps/{appId}/groups".expanded(using: [
+                        "appId": appId
+                    ]), method: "GET", query: [
+                        "q": q, 
+                        "after": after, 
+                        "limit": limit, 
+                        "expand": expand
+                    ]), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          List all Key Credentials
          
          - parameter appId: (path)  
@@ -368,6 +815,22 @@ public extension OktaClient {
             try await send(try request(to: "/api/v1/apps/{appId}/credentials/keys".expanded(using: [
                     "appId": appId
                 ]), method: "GET"))
+        }
+
+        /**
+         List all Key Credentials
+         
+         - parameter appId: (path)  
+         - parameter completion: Completion block
+         */
+        public func listApplicationKeys(appId: String, completion: @escaping (Result<OktaResponse<[JsonWebKey]>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/apps/{appId}/credentials/keys".expanded(using: [
+                        "appId": appId
+                    ]), method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -395,6 +858,35 @@ public extension OktaClient {
         }
 
         /**
+         List all Assigned Users
+         
+         - parameter appId: (path)  
+         - parameter q: (query)  (optional)
+         - parameter queryScope: (query)  (optional)
+         - parameter after: (query) specifies the pagination cursor for the next page of assignments (optional)
+         - parameter limit: (query) specifies the number of results for a page (optional, default to -1)
+         - parameter filter: (query)  (optional)
+         - parameter expand: (query)  (optional)
+         - parameter completion: Completion block
+         */
+        public func listApplicationUsers(appId: String, q: String? = nil, queryScope: String? = nil, after: String? = nil, limit: Int? = nil, filter: String? = nil, expand: String? = nil, completion: @escaping (Result<OktaResponse<[AppUser]>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/apps/{appId}/users".expanded(using: [
+                        "appId": appId
+                    ]), method: "GET", query: [
+                        "q": q, 
+                        "queryScope": queryScope, 
+                        "after": after, 
+                        "limit": limit, 
+                        "filter": filter, 
+                        "expand": expand
+                    ]), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          List all Applications
          
          - parameter q: (query)  (optional)
@@ -416,6 +908,32 @@ public extension OktaClient {
         }
 
         /**
+         List all Applications
+         
+         - parameter q: (query)  (optional)
+         - parameter after: (query) Specifies the pagination cursor for the next page of apps (optional)
+         - parameter limit: (query) Specifies the number of results for a page (optional, default to -1)
+         - parameter filter: (query) Filters apps by status, user.id, group.id or credentials.signing.kid expression (optional)
+         - parameter expand: (query) Traverses users link relationship and optionally embeds Application User resource (optional)
+         - parameter includeNonDeleted: (query)  (optional, default to false)
+         - parameter completion: Completion block
+         */
+        public func listApplications(q: String? = nil, after: String? = nil, limit: Int? = nil, filter: String? = nil, expand: String? = nil, includeNonDeleted: Bool? = nil, completion: @escaping (Result<OktaResponse<[Application]>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/apps", method: "GET", query: [
+                        "q": q, 
+                        "after": after, 
+                        "limit": limit, 
+                        "filter": filter, 
+                        "expand": expand, 
+                        "includeNonDeleted": includeNonDeleted
+                    ]), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          List all Certificate Signing Requests
          
          - parameter appId: (path)  
@@ -427,6 +945,22 @@ public extension OktaClient {
         }
 
         /**
+         List all Certificate Signing Requests
+         
+         - parameter appId: (path)  
+         - parameter completion: Completion block
+         */
+        public func listCsrsForApplication(appId: String, completion: @escaping (Result<OktaResponse<[Csr]>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/apps/{appId}/credentials/csrs".expanded(using: [
+                        "appId": appId
+                    ]), method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          List all Features
          
          - parameter appId: (path)  
@@ -435,6 +969,22 @@ public extension OktaClient {
             try await send(try request(to: "/api/v1/apps/{appId}/features".expanded(using: [
                     "appId": appId
                 ]), method: "GET"))
+        }
+
+        /**
+         List all Features
+         
+         - parameter appId: (path)  
+         - parameter completion: Completion block
+         */
+        public func listFeaturesForApplication(appId: String, completion: @escaping (Result<OktaResponse<[ApplicationFeature]>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/apps/{appId}/features".expanded(using: [
+                        "appId": appId
+                    ]), method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -456,6 +1006,29 @@ public extension OktaClient {
         }
 
         /**
+         List all OAuth 2.0 Tokens
+         
+         - parameter appId: (path)  
+         - parameter expand: (query)  (optional)
+         - parameter after: (query)  (optional)
+         - parameter limit: (query)  (optional, default to 20)
+         - parameter completion: Completion block
+         */
+        public func listOAuth2TokensForApplication(appId: String, expand: String? = nil, after: String? = nil, limit: Int? = nil, completion: @escaping (Result<OktaResponse<[OAuth2Token]>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/apps/{appId}/tokens".expanded(using: [
+                        "appId": appId
+                    ]), method: "GET", query: [
+                        "expand": expand, 
+                        "after": after, 
+                        "limit": limit
+                    ]), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          List all Scope Consent Grants
          
          - parameter appId: (path)  
@@ -467,6 +1040,25 @@ public extension OktaClient {
                 ]), method: "GET", query: [
                     "expand": expand
                 ]))
+        }
+
+        /**
+         List all Scope Consent Grants
+         
+         - parameter appId: (path)  
+         - parameter expand: (query)  (optional)
+         - parameter completion: Completion block
+         */
+        public func listScopeConsentGrants(appId: String, expand: String? = nil, completion: @escaping (Result<OktaResponse<[OAuth2ScopeConsentGrant]>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/apps/{appId}/grants".expanded(using: [
+                        "appId": appId
+                    ]), method: "GET", query: [
+                        "expand": expand
+                    ]), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -484,6 +1076,25 @@ public extension OktaClient {
         }
 
         /**
+         Publish a Certificate Signing Request
+         
+         - parameter appId: (path)  
+         - parameter csrId: (path)  
+         - parameter body: (body)  
+         - parameter completion: Completion block
+         */
+        public func publishCsrFromApplication(appId: String, csrId: String, body: URL, completion: @escaping (Result<OktaResponse<JsonWebKey>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/apps/{appId}/credentials/csrs/{csrId}/lifecycle/publish".expanded(using: [
+                        "appId": appId, 
+                        "csrId": csrId
+                    ]), method: "POST", body: body), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Revoke a Certificate Signing Request
          
          - parameter appId: (path)  
@@ -495,6 +1106,24 @@ public extension OktaClient {
                     "appId": appId, 
                     "csrId": csrId
                 ]), method: "DELETE"))
+        }
+
+        /**
+         Revoke a Certificate Signing Request
+         
+         - parameter appId: (path)  
+         - parameter csrId: (path)  
+         - parameter completion: Completion block
+         */
+        public func revokeCsrFromApplication(appId: String, csrId: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/apps/{appId}/credentials/csrs/{csrId}".expanded(using: [
+                        "appId": appId, 
+                        "csrId": csrId
+                    ]), method: "DELETE"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -512,6 +1141,24 @@ public extension OktaClient {
         }
 
         /**
+         Revoke an OAuth 2.0 Token
+         
+         - parameter appId: (path)  
+         - parameter tokenId: (path)  
+         - parameter completion: Completion block
+         */
+        public func revokeOAuth2TokenForApplication(appId: String, tokenId: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/apps/{appId}/tokens/{tokenId}".expanded(using: [
+                        "appId": appId, 
+                        "tokenId": tokenId
+                    ]), method: "DELETE"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Revoke all OAuth 2.0 Tokens
          
          - parameter appId: (path)  
@@ -521,6 +1168,22 @@ public extension OktaClient {
             try await send(try request(to: "/api/v1/apps/{appId}/tokens".expanded(using: [
                     "appId": appId
                 ]), method: "DELETE"))
+        }
+
+        /**
+         Revoke all OAuth 2.0 Tokens
+         
+         - parameter appId: (path)  
+         - parameter completion: Completion block
+         */
+        public func revokeOAuth2TokensForApplication(appId: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/apps/{appId}/tokens".expanded(using: [
+                        "appId": appId
+                    ]), method: "DELETE"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -535,6 +1198,24 @@ public extension OktaClient {
                     "appId": appId, 
                     "grantId": grantId
                 ]), method: "DELETE"))
+        }
+
+        /**
+         Revoke a Scope Consent Grant
+         
+         - parameter appId: (path)  
+         - parameter grantId: (path)  
+         - parameter completion: Completion block
+         */
+        public func revokeScopeConsentGrant(appId: String, grantId: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/apps/{appId}/grants/{grantId}".expanded(using: [
+                        "appId": appId, 
+                        "grantId": grantId
+                    ]), method: "DELETE"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -553,6 +1234,26 @@ public extension OktaClient {
         }
 
         /**
+         Update the default Provisioning Connection
+         
+         - parameter appId: (path)  
+         - parameter provisioningConnectionRequest: (body)  
+         - parameter activate: (query)  (optional)
+         - parameter completion: Completion block
+         */
+        public func setDefaultProvisioningConnectionForApplication(appId: String, provisioningConnectionRequest: ProvisioningConnectionRequest, activate: Bool? = nil, completion: @escaping (Result<OktaResponse<ProvisioningConnection>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/apps/{appId}/connections/default".expanded(using: [
+                        "appId": appId
+                    ]), method: "POST", query: [
+                        "activate": activate
+                    ], body: provisioningConnectionRequest), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Replace an Application
          
          - parameter appId: (path)  
@@ -562,6 +1263,23 @@ public extension OktaClient {
             try await send(try requestWithBody(to: "/api/v1/apps/{appId}".expanded(using: [
                     "appId": appId
                 ]), method: "PUT", body: application))
+        }
+
+        /**
+         Replace an Application
+         
+         - parameter appId: (path)  
+         - parameter application: (body)  
+         - parameter completion: Completion block
+         */
+        public func updateApplication(appId: String, application: Application, completion: @escaping (Result<OktaResponse<Application>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/apps/{appId}".expanded(using: [
+                        "appId": appId
+                    ]), method: "PUT", body: application), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -579,6 +1297,25 @@ public extension OktaClient {
         }
 
         /**
+         Update an Application Profile for Assigned User
+         
+         - parameter appId: (path)  
+         - parameter userId: (path)  
+         - parameter appUser: (body)  
+         - parameter completion: Completion block
+         */
+        public func updateApplicationUser(appId: String, userId: String, appUser: AppUser, completion: @escaping (Result<OktaResponse<AppUser>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/apps/{appId}/users/{userId}".expanded(using: [
+                        "appId": appId, 
+                        "userId": userId
+                    ]), method: "POST", body: appUser), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Update a Feature
          
          - parameter appId: (path)  
@@ -593,6 +1330,25 @@ public extension OktaClient {
         }
 
         /**
+         Update a Feature
+         
+         - parameter appId: (path)  
+         - parameter name: (path)  
+         - parameter capabilitiesObject: (body)  
+         - parameter completion: Completion block
+         */
+        public func updateFeatureForApplication(appId: String, name: String, capabilitiesObject: CapabilitiesObject, completion: @escaping (Result<OktaResponse<ApplicationFeature>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/apps/{appId}/features/{name}".expanded(using: [
+                        "appId": appId, 
+                        "name": name
+                    ]), method: "PUT", body: capabilitiesObject), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Upload a Logo
          
          - parameter appId: (path)  
@@ -603,6 +1359,23 @@ public extension OktaClient {
             try await send(try request(to: "/api/v1/apps/{appId}/logo".expanded(using: [
                     "appId": appId
                 ]), method: "POST"))
+        }
+
+        /**
+         Upload a Logo
+         
+         - parameter appId: (path)  
+         - parameter file: (form)  
+         - parameter completion: Completion block
+         */
+        public func uploadApplicationLogo(appId: String, file: URL, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/apps/{appId}/logo".expanded(using: [
+                        "appId": appId
+                    ]), method: "POST"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
     }

--- a/Sources/OktaSdk/ManagementAPI/OktaSdk/AuthenticatorAPI.swift
+++ b/Sources/OktaSdk/ManagementAPI/OktaSdk/AuthenticatorAPI.swift
@@ -37,6 +37,22 @@ public extension OktaClient {
         }
 
         /**
+         Activate an Authenticator
+         
+         - parameter authenticatorId: (path)  
+         - parameter completion: Completion block
+         */
+        public func activateAuthenticator(authenticatorId: String, completion: @escaping (Result<OktaResponse<Authenticator>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/authenticators/{authenticatorId}/lifecycle/activate".expanded(using: [
+                        "authenticatorId": authenticatorId
+                    ]), method: "POST"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Deactivate an Authenticator
          
          - parameter authenticatorId: (path)  
@@ -45,6 +61,22 @@ public extension OktaClient {
             try await send(try request(to: "/api/v1/authenticators/{authenticatorId}/lifecycle/deactivate".expanded(using: [
                     "authenticatorId": authenticatorId
                 ]), method: "POST"))
+        }
+
+        /**
+         Deactivate an Authenticator
+         
+         - parameter authenticatorId: (path)  
+         - parameter completion: Completion block
+         */
+        public func deactivateAuthenticator(authenticatorId: String, completion: @escaping (Result<OktaResponse<Authenticator>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/authenticators/{authenticatorId}/lifecycle/deactivate".expanded(using: [
+                        "authenticatorId": authenticatorId
+                    ]), method: "POST"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -59,11 +91,40 @@ public extension OktaClient {
         }
 
         /**
+         Retrieve an Authenticator
+         
+         - parameter authenticatorId: (path)  
+         - parameter completion: Completion block
+         */
+        public func getAuthenticator(authenticatorId: String, completion: @escaping (Result<OktaResponse<Authenticator>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/authenticators/{authenticatorId}".expanded(using: [
+                        "authenticatorId": authenticatorId
+                    ]), method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          List all Authenticators
          
          */
         public func listAuthenticators() async throws -> OktaResponse<[Authenticator]> {
             try await send(try request(to: "/api/v1/authenticators", method: "GET"))
+        }
+
+        /**
+         List all Authenticators
+         
+         - parameter completion: Completion block
+         */
+        public func listAuthenticators(completion: @escaping (Result<OktaResponse<[Authenticator]>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/authenticators", method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -76,6 +137,23 @@ public extension OktaClient {
             try await send(try requestWithBody(to: "/api/v1/authenticators/{authenticatorId}".expanded(using: [
                     "authenticatorId": authenticatorId
                 ]), method: "PUT", body: authenticator))
+        }
+
+        /**
+         Replace an Authenticator
+         
+         - parameter authenticatorId: (path)  
+         - parameter authenticator: (body)  
+         - parameter completion: Completion block
+         */
+        public func updateAuthenticator(authenticatorId: String, authenticator: Authenticator, completion: @escaping (Result<OktaResponse<Authenticator>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/authenticators/{authenticatorId}".expanded(using: [
+                        "authenticatorId": authenticatorId
+                    ]), method: "PUT", body: authenticator), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
     }

--- a/Sources/OktaSdk/ManagementAPI/OktaSdk/AuthorizationServerAPI.swift
+++ b/Sources/OktaSdk/ManagementAPI/OktaSdk/AuthorizationServerAPI.swift
@@ -38,6 +38,22 @@ public extension OktaClient {
         }
 
         /**
+         Activate an Authorization Server
+         
+         - parameter authServerId: (path)  
+         - parameter completion: Completion block
+         */
+        public func activateAuthorizationServer(authServerId: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/authorizationServers/{authServerId}/lifecycle/activate".expanded(using: [
+                        "authServerId": authServerId
+                    ]), method: "POST"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Activate a Policy
          
          - parameter authServerId: (path)  
@@ -49,6 +65,24 @@ public extension OktaClient {
                     "authServerId": authServerId, 
                     "policyId": policyId
                 ]), method: "POST"))
+        }
+
+        /**
+         Activate a Policy
+         
+         - parameter authServerId: (path)  
+         - parameter policyId: (path)  
+         - parameter completion: Completion block
+         */
+        public func activateAuthorizationServerPolicy(authServerId: String, policyId: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/authorizationServers/{authServerId}/policies/{policyId}/lifecycle/activate".expanded(using: [
+                        "authServerId": authServerId, 
+                        "policyId": policyId
+                    ]), method: "POST"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -68,12 +102,46 @@ public extension OktaClient {
         }
 
         /**
+         Activate a Policy Rule
+         
+         - parameter authServerId: (path)  
+         - parameter policyId: (path)  
+         - parameter ruleId: (path)  
+         - parameter completion: Completion block
+         */
+        public func activateAuthorizationServerPolicyRule(authServerId: String, policyId: String, ruleId: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/authorizationServers/{authServerId}/policies/{policyId}/rules/{ruleId}/lifecycle/activate".expanded(using: [
+                        "authServerId": authServerId, 
+                        "policyId": policyId, 
+                        "ruleId": ruleId
+                    ]), method: "POST"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Create an Authorization Server
          
          - parameter authorizationServer: (body)  
          */
         public func createAuthorizationServer(authorizationServer: AuthorizationServer) async throws -> OktaResponse<AuthorizationServer> {
             try await send(try requestWithBody(to: "/api/v1/authorizationServers", method: "POST", body: authorizationServer))
+        }
+
+        /**
+         Create an Authorization Server
+         
+         - parameter authorizationServer: (body)  
+         - parameter completion: Completion block
+         */
+        public func createAuthorizationServer(authorizationServer: AuthorizationServer, completion: @escaping (Result<OktaResponse<AuthorizationServer>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/authorizationServers", method: "POST", body: authorizationServer), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -86,6 +154,23 @@ public extension OktaClient {
             try await send(try requestWithBody(to: "/api/v1/authorizationServers/{authServerId}/policies".expanded(using: [
                     "authServerId": authServerId
                 ]), method: "POST", body: policy))
+        }
+
+        /**
+         Create a Policy
+         
+         - parameter authServerId: (path)  
+         - parameter policy: (body)  
+         - parameter completion: Completion block
+         */
+        public func createAuthorizationServerPolicy(authServerId: String, policy: AuthorizationServerPolicy, completion: @escaping (Result<OktaResponse<AuthorizationServerPolicy>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/authorizationServers/{authServerId}/policies".expanded(using: [
+                        "authServerId": authServerId
+                    ]), method: "POST", body: policy), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -103,6 +188,25 @@ public extension OktaClient {
         }
 
         /**
+         Create a Policy Rule
+         
+         - parameter policyId: (path)  
+         - parameter authServerId: (path)  
+         - parameter policyRule: (body)  
+         - parameter completion: Completion block
+         */
+        public func createAuthorizationServerPolicyRule(policyId: String, authServerId: String, policyRule: AuthorizationServerPolicyRule, completion: @escaping (Result<OktaResponse<AuthorizationServerPolicyRule>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/authorizationServers/{authServerId}/policies/{policyId}/rules".expanded(using: [
+                        "policyId": policyId, 
+                        "authServerId": authServerId
+                    ]), method: "POST", body: policyRule), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Create a Custom Token Claim
          
          - parameter authServerId: (path)  
@@ -112,6 +216,23 @@ public extension OktaClient {
             try await send(try requestWithBody(to: "/api/v1/authorizationServers/{authServerId}/claims".expanded(using: [
                     "authServerId": authServerId
                 ]), method: "POST", body: oAuth2Claim))
+        }
+
+        /**
+         Create a Custom Token Claim
+         
+         - parameter authServerId: (path)  
+         - parameter oAuth2Claim: (body)  
+         - parameter completion: Completion block
+         */
+        public func createOAuth2Claim(authServerId: String, oAuth2Claim: OAuth2Claim, completion: @escaping (Result<OktaResponse<OAuth2Claim>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/authorizationServers/{authServerId}/claims".expanded(using: [
+                        "authServerId": authServerId
+                    ]), method: "POST", body: oAuth2Claim), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -127,6 +248,23 @@ public extension OktaClient {
         }
 
         /**
+         Create a Custom Token Scope
+         
+         - parameter authServerId: (path)  
+         - parameter oAuth2Scope: (body)  
+         - parameter completion: Completion block
+         */
+        public func createOAuth2Scope(authServerId: String, oAuth2Scope: OAuth2Scope, completion: @escaping (Result<OktaResponse<OAuth2Scope>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/authorizationServers/{authServerId}/scopes".expanded(using: [
+                        "authServerId": authServerId
+                    ]), method: "POST", body: oAuth2Scope), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Deactivate an Authorization Server
          
          - parameter authServerId: (path)  
@@ -136,6 +274,22 @@ public extension OktaClient {
             try await send(try request(to: "/api/v1/authorizationServers/{authServerId}/lifecycle/deactivate".expanded(using: [
                     "authServerId": authServerId
                 ]), method: "POST"))
+        }
+
+        /**
+         Deactivate an Authorization Server
+         
+         - parameter authServerId: (path)  
+         - parameter completion: Completion block
+         */
+        public func deactivateAuthorizationServer(authServerId: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/authorizationServers/{authServerId}/lifecycle/deactivate".expanded(using: [
+                        "authServerId": authServerId
+                    ]), method: "POST"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -150,6 +304,24 @@ public extension OktaClient {
                     "authServerId": authServerId, 
                     "policyId": policyId
                 ]), method: "POST"))
+        }
+
+        /**
+         Deactivate a Policy
+         
+         - parameter authServerId: (path)  
+         - parameter policyId: (path)  
+         - parameter completion: Completion block
+         */
+        public func deactivateAuthorizationServerPolicy(authServerId: String, policyId: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/authorizationServers/{authServerId}/policies/{policyId}/lifecycle/deactivate".expanded(using: [
+                        "authServerId": authServerId, 
+                        "policyId": policyId
+                    ]), method: "POST"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -169,6 +341,26 @@ public extension OktaClient {
         }
 
         /**
+         Deactivate a Policy Rule
+         
+         - parameter authServerId: (path)  
+         - parameter policyId: (path)  
+         - parameter ruleId: (path)  
+         - parameter completion: Completion block
+         */
+        public func deactivateAuthorizationServerPolicyRule(authServerId: String, policyId: String, ruleId: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/authorizationServers/{authServerId}/policies/{policyId}/rules/{ruleId}/lifecycle/deactivate".expanded(using: [
+                        "authServerId": authServerId, 
+                        "policyId": policyId, 
+                        "ruleId": ruleId
+                    ]), method: "POST"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Delete an Authorization Server
          
          - parameter authServerId: (path)  
@@ -178,6 +370,22 @@ public extension OktaClient {
             try await send(try request(to: "/api/v1/authorizationServers/{authServerId}".expanded(using: [
                     "authServerId": authServerId
                 ]), method: "DELETE"))
+        }
+
+        /**
+         Delete an Authorization Server
+         
+         - parameter authServerId: (path)  
+         - parameter completion: Completion block
+         */
+        public func deleteAuthorizationServer(authServerId: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/authorizationServers/{authServerId}".expanded(using: [
+                        "authServerId": authServerId
+                    ]), method: "DELETE"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -192,6 +400,24 @@ public extension OktaClient {
                     "authServerId": authServerId, 
                     "policyId": policyId
                 ]), method: "DELETE"))
+        }
+
+        /**
+         Delete a Policy
+         
+         - parameter authServerId: (path)  
+         - parameter policyId: (path)  
+         - parameter completion: Completion block
+         */
+        public func deleteAuthorizationServerPolicy(authServerId: String, policyId: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/authorizationServers/{authServerId}/policies/{policyId}".expanded(using: [
+                        "authServerId": authServerId, 
+                        "policyId": policyId
+                    ]), method: "DELETE"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -211,6 +437,26 @@ public extension OktaClient {
         }
 
         /**
+         Delete a Policy Rule
+         
+         - parameter policyId: (path)  
+         - parameter authServerId: (path)  
+         - parameter ruleId: (path)  
+         - parameter completion: Completion block
+         */
+        public func deleteAuthorizationServerPolicyRule(policyId: String, authServerId: String, ruleId: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/authorizationServers/{authServerId}/policies/{policyId}/rules/{ruleId}".expanded(using: [
+                        "policyId": policyId, 
+                        "authServerId": authServerId, 
+                        "ruleId": ruleId
+                    ]), method: "DELETE"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Delete a Custom Token Claim
          
          - parameter authServerId: (path)  
@@ -222,6 +468,24 @@ public extension OktaClient {
                     "authServerId": authServerId, 
                     "claimId": claimId
                 ]), method: "DELETE"))
+        }
+
+        /**
+         Delete a Custom Token Claim
+         
+         - parameter authServerId: (path)  
+         - parameter claimId: (path)  
+         - parameter completion: Completion block
+         */
+        public func deleteOAuth2Claim(authServerId: String, claimId: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/authorizationServers/{authServerId}/claims/{claimId}".expanded(using: [
+                        "authServerId": authServerId, 
+                        "claimId": claimId
+                    ]), method: "DELETE"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -239,6 +503,24 @@ public extension OktaClient {
         }
 
         /**
+         Delete a Custom Token Scope
+         
+         - parameter authServerId: (path)  
+         - parameter scopeId: (path)  
+         - parameter completion: Completion block
+         */
+        public func deleteOAuth2Scope(authServerId: String, scopeId: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/authorizationServers/{authServerId}/scopes/{scopeId}".expanded(using: [
+                        "authServerId": authServerId, 
+                        "scopeId": scopeId
+                    ]), method: "DELETE"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Retrieve an Authorization Server
          
          - parameter authServerId: (path)  
@@ -247,6 +529,22 @@ public extension OktaClient {
             try await send(try request(to: "/api/v1/authorizationServers/{authServerId}".expanded(using: [
                     "authServerId": authServerId
                 ]), method: "GET"))
+        }
+
+        /**
+         Retrieve an Authorization Server
+         
+         - parameter authServerId: (path)  
+         - parameter completion: Completion block
+         */
+        public func getAuthorizationServer(authServerId: String, completion: @escaping (Result<OktaResponse<AuthorizationServer>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/authorizationServers/{authServerId}".expanded(using: [
+                        "authServerId": authServerId
+                    ]), method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -260,6 +558,24 @@ public extension OktaClient {
                     "authServerId": authServerId, 
                     "policyId": policyId
                 ]), method: "GET"))
+        }
+
+        /**
+         Retrieve a Policy
+         
+         - parameter authServerId: (path)  
+         - parameter policyId: (path)  
+         - parameter completion: Completion block
+         */
+        public func getAuthorizationServerPolicy(authServerId: String, policyId: String, completion: @escaping (Result<OktaResponse<AuthorizationServerPolicy>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/authorizationServers/{authServerId}/policies/{policyId}".expanded(using: [
+                        "authServerId": authServerId, 
+                        "policyId": policyId
+                    ]), method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -278,6 +594,26 @@ public extension OktaClient {
         }
 
         /**
+         Retrieve a Policy Rule
+         
+         - parameter policyId: (path)  
+         - parameter authServerId: (path)  
+         - parameter ruleId: (path)  
+         - parameter completion: Completion block
+         */
+        public func getAuthorizationServerPolicyRule(policyId: String, authServerId: String, ruleId: String, completion: @escaping (Result<OktaResponse<AuthorizationServerPolicyRule>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/authorizationServers/{authServerId}/policies/{policyId}/rules/{ruleId}".expanded(using: [
+                        "policyId": policyId, 
+                        "authServerId": authServerId, 
+                        "ruleId": ruleId
+                    ]), method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Retrieve a Custom Token Claim
          
          - parameter authServerId: (path)  
@@ -291,6 +627,24 @@ public extension OktaClient {
         }
 
         /**
+         Retrieve a Custom Token Claim
+         
+         - parameter authServerId: (path)  
+         - parameter claimId: (path)  
+         - parameter completion: Completion block
+         */
+        public func getOAuth2Claim(authServerId: String, claimId: String, completion: @escaping (Result<OktaResponse<OAuth2Claim>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/authorizationServers/{authServerId}/claims/{claimId}".expanded(using: [
+                        "authServerId": authServerId, 
+                        "claimId": claimId
+                    ]), method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Retrieve a Custom Token Scope
          
          - parameter authServerId: (path)  
@@ -301,6 +655,24 @@ public extension OktaClient {
                     "authServerId": authServerId, 
                     "scopeId": scopeId
                 ]), method: "GET"))
+        }
+
+        /**
+         Retrieve a Custom Token Scope
+         
+         - parameter authServerId: (path)  
+         - parameter scopeId: (path)  
+         - parameter completion: Completion block
+         */
+        public func getOAuth2Scope(authServerId: String, scopeId: String, completion: @escaping (Result<OktaResponse<OAuth2Scope>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/authorizationServers/{authServerId}/scopes/{scopeId}".expanded(using: [
+                        "authServerId": authServerId, 
+                        "scopeId": scopeId
+                    ]), method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -322,6 +694,29 @@ public extension OktaClient {
         }
 
         /**
+         Retrieve a Refresh Token for a Client
+         
+         - parameter authServerId: (path)  
+         - parameter clientId: (path)  
+         - parameter tokenId: (path)  
+         - parameter expand: (query)  (optional)
+         - parameter completion: Completion block
+         */
+        public func getRefreshTokenForAuthorizationServerAndClient(authServerId: String, clientId: String, tokenId: String, expand: String? = nil, completion: @escaping (Result<OktaResponse<OAuth2RefreshToken>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/authorizationServers/{authServerId}/clients/{clientId}/tokens/{tokenId}".expanded(using: [
+                        "authServerId": authServerId, 
+                        "clientId": clientId, 
+                        "tokenId": tokenId
+                    ]), method: "GET", query: [
+                        "expand": expand
+                    ]), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          List all Credential Keys
          
          - parameter authServerId: (path)  
@@ -330,6 +725,22 @@ public extension OktaClient {
             try await send(try request(to: "/api/v1/authorizationServers/{authServerId}/credentials/keys".expanded(using: [
                     "authServerId": authServerId
                 ]), method: "GET"))
+        }
+
+        /**
+         List all Credential Keys
+         
+         - parameter authServerId: (path)  
+         - parameter completion: Completion block
+         */
+        public func listAuthorizationServerKeys(authServerId: String, completion: @escaping (Result<OktaResponse<[JsonWebKey]>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/authorizationServers/{authServerId}/credentials/keys".expanded(using: [
+                        "authServerId": authServerId
+                    ]), method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -344,6 +755,22 @@ public extension OktaClient {
         }
 
         /**
+         List all Policies
+         
+         - parameter authServerId: (path)  
+         - parameter completion: Completion block
+         */
+        public func listAuthorizationServerPolicies(authServerId: String, completion: @escaping (Result<OktaResponse<[AuthorizationServerPolicy]>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/authorizationServers/{authServerId}/policies".expanded(using: [
+                        "authServerId": authServerId
+                    ]), method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          List all Policy Rules
          
          - parameter policyId: (path)  
@@ -354,6 +781,24 @@ public extension OktaClient {
                     "policyId": policyId, 
                     "authServerId": authServerId
                 ]), method: "GET"))
+        }
+
+        /**
+         List all Policy Rules
+         
+         - parameter policyId: (path)  
+         - parameter authServerId: (path)  
+         - parameter completion: Completion block
+         */
+        public func listAuthorizationServerPolicyRules(policyId: String, authServerId: String, completion: @escaping (Result<OktaResponse<[AuthorizationServerPolicyRule]>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/authorizationServers/{authServerId}/policies/{policyId}/rules".expanded(using: [
+                        "policyId": policyId, 
+                        "authServerId": authServerId
+                    ]), method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -372,6 +817,26 @@ public extension OktaClient {
         }
 
         /**
+         List all Authorization Servers
+         
+         - parameter q: (query)  (optional)
+         - parameter limit: (query)  (optional)
+         - parameter after: (query)  (optional)
+         - parameter completion: Completion block
+         */
+        public func listAuthorizationServers(q: String? = nil, limit: String? = nil, after: String? = nil, completion: @escaping (Result<OktaResponse<[AuthorizationServer]>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/authorizationServers", method: "GET", query: [
+                        "q": q, 
+                        "limit": limit, 
+                        "after": after
+                    ]), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          List all Custom Token Claims
          
          - parameter authServerId: (path)  
@@ -383,6 +848,22 @@ public extension OktaClient {
         }
 
         /**
+         List all Custom Token Claims
+         
+         - parameter authServerId: (path)  
+         - parameter completion: Completion block
+         */
+        public func listOAuth2Claims(authServerId: String, completion: @escaping (Result<OktaResponse<[OAuth2Claim]>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/authorizationServers/{authServerId}/claims".expanded(using: [
+                        "authServerId": authServerId
+                    ]), method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          List all Clients
          
          - parameter authServerId: (path)  
@@ -391,6 +872,22 @@ public extension OktaClient {
             try await send(try request(to: "/api/v1/authorizationServers/{authServerId}/clients".expanded(using: [
                     "authServerId": authServerId
                 ]), method: "GET"))
+        }
+
+        /**
+         List all Clients
+         
+         - parameter authServerId: (path)  
+         - parameter completion: Completion block
+         */
+        public func listOAuth2ClientsForAuthorizationServer(authServerId: String, completion: @escaping (Result<OktaResponse<[OAuth2Client]>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/authorizationServers/{authServerId}/clients".expanded(using: [
+                        "authServerId": authServerId
+                    ]), method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -414,6 +911,31 @@ public extension OktaClient {
         }
 
         /**
+         List all Custom Token Scopes
+         
+         - parameter authServerId: (path)  
+         - parameter q: (query)  (optional)
+         - parameter filter: (query)  (optional)
+         - parameter cursor: (query)  (optional)
+         - parameter limit: (query)  (optional, default to -1)
+         - parameter completion: Completion block
+         */
+        public func listOAuth2Scopes(authServerId: String, q: String? = nil, filter: String? = nil, cursor: String? = nil, limit: Int? = nil, completion: @escaping (Result<OktaResponse<[OAuth2Scope]>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/authorizationServers/{authServerId}/scopes".expanded(using: [
+                        "authServerId": authServerId
+                    ]), method: "GET", query: [
+                        "q": q, 
+                        "filter": filter, 
+                        "cursor": cursor, 
+                        "limit": limit
+                    ]), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          List all Refresh Tokens for a Client
          
          - parameter authServerId: (path)  
@@ -434,6 +956,31 @@ public extension OktaClient {
         }
 
         /**
+         List all Refresh Tokens for a Client
+         
+         - parameter authServerId: (path)  
+         - parameter clientId: (path)  
+         - parameter expand: (query)  (optional)
+         - parameter after: (query)  (optional)
+         - parameter limit: (query)  (optional, default to -1)
+         - parameter completion: Completion block
+         */
+        public func listRefreshTokensForAuthorizationServerAndClient(authServerId: String, clientId: String, expand: String? = nil, after: String? = nil, limit: Int? = nil, completion: @escaping (Result<OktaResponse<[OAuth2RefreshToken]>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/authorizationServers/{authServerId}/clients/{clientId}/tokens".expanded(using: [
+                        "authServerId": authServerId, 
+                        "clientId": clientId
+                    ]), method: "GET", query: [
+                        "expand": expand, 
+                        "after": after, 
+                        "limit": limit
+                    ]), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Revoke a Refresh Token for a Client
          
          - parameter authServerId: (path)  
@@ -447,6 +994,26 @@ public extension OktaClient {
                     "clientId": clientId, 
                     "tokenId": tokenId
                 ]), method: "DELETE"))
+        }
+
+        /**
+         Revoke a Refresh Token for a Client
+         
+         - parameter authServerId: (path)  
+         - parameter clientId: (path)  
+         - parameter tokenId: (path)  
+         - parameter completion: Completion block
+         */
+        public func revokeRefreshTokenForAuthorizationServerAndClient(authServerId: String, clientId: String, tokenId: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/authorizationServers/{authServerId}/clients/{clientId}/tokens/{tokenId}".expanded(using: [
+                        "authServerId": authServerId, 
+                        "clientId": clientId, 
+                        "tokenId": tokenId
+                    ]), method: "DELETE"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -464,6 +1031,24 @@ public extension OktaClient {
         }
 
         /**
+         Revoke all Refresh Tokens for a Client
+         
+         - parameter authServerId: (path)  
+         - parameter clientId: (path)  
+         - parameter completion: Completion block
+         */
+        public func revokeRefreshTokensForAuthorizationServerAndClient(authServerId: String, clientId: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/authorizationServers/{authServerId}/clients/{clientId}/tokens".expanded(using: [
+                        "authServerId": authServerId, 
+                        "clientId": clientId
+                    ]), method: "DELETE"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Rotate all Credential Keys
          
          - parameter authServerId: (path)  
@@ -473,6 +1058,23 @@ public extension OktaClient {
             try await send(try requestWithBody(to: "/api/v1/authorizationServers/{authServerId}/credentials/lifecycle/keyRotate".expanded(using: [
                     "authServerId": authServerId
                 ]), method: "POST", body: use))
+        }
+
+        /**
+         Rotate all Credential Keys
+         
+         - parameter authServerId: (path)  
+         - parameter use: (body)  
+         - parameter completion: Completion block
+         */
+        public func rotateAuthorizationServerKeys(authServerId: String, use: JwkUse, completion: @escaping (Result<OktaResponse<[JsonWebKey]>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/authorizationServers/{authServerId}/credentials/lifecycle/keyRotate".expanded(using: [
+                        "authServerId": authServerId
+                    ]), method: "POST", body: use), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -488,6 +1090,23 @@ public extension OktaClient {
         }
 
         /**
+         Replace an Authorization Server
+         
+         - parameter authServerId: (path)  
+         - parameter authorizationServer: (body)  
+         - parameter completion: Completion block
+         */
+        public func updateAuthorizationServer(authServerId: String, authorizationServer: AuthorizationServer, completion: @escaping (Result<OktaResponse<AuthorizationServer>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/authorizationServers/{authServerId}".expanded(using: [
+                        "authServerId": authServerId
+                    ]), method: "PUT", body: authorizationServer), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Replace a Policy
          
          - parameter authServerId: (path)  
@@ -499,6 +1118,25 @@ public extension OktaClient {
                     "authServerId": authServerId, 
                     "policyId": policyId
                 ]), method: "PUT", body: policy))
+        }
+
+        /**
+         Replace a Policy
+         
+         - parameter authServerId: (path)  
+         - parameter policyId: (path)  
+         - parameter policy: (body)  
+         - parameter completion: Completion block
+         */
+        public func updateAuthorizationServerPolicy(authServerId: String, policyId: String, policy: AuthorizationServerPolicy, completion: @escaping (Result<OktaResponse<AuthorizationServerPolicy>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/authorizationServers/{authServerId}/policies/{policyId}".expanded(using: [
+                        "authServerId": authServerId, 
+                        "policyId": policyId
+                    ]), method: "PUT", body: policy), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -518,6 +1156,27 @@ public extension OktaClient {
         }
 
         /**
+         Replace a Policy Rule
+         
+         - parameter policyId: (path)  
+         - parameter authServerId: (path)  
+         - parameter ruleId: (path)  
+         - parameter policyRule: (body)  
+         - parameter completion: Completion block
+         */
+        public func updateAuthorizationServerPolicyRule(policyId: String, authServerId: String, ruleId: String, policyRule: AuthorizationServerPolicyRule, completion: @escaping (Result<OktaResponse<AuthorizationServerPolicyRule>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/authorizationServers/{authServerId}/policies/{policyId}/rules/{ruleId}".expanded(using: [
+                        "policyId": policyId, 
+                        "authServerId": authServerId, 
+                        "ruleId": ruleId
+                    ]), method: "PUT", body: policyRule), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Replace a Custom Token Claim
          
          - parameter authServerId: (path)  
@@ -532,6 +1191,25 @@ public extension OktaClient {
         }
 
         /**
+         Replace a Custom Token Claim
+         
+         - parameter authServerId: (path)  
+         - parameter claimId: (path)  
+         - parameter oAuth2Claim: (body)  
+         - parameter completion: Completion block
+         */
+        public func updateOAuth2Claim(authServerId: String, claimId: String, oAuth2Claim: OAuth2Claim, completion: @escaping (Result<OktaResponse<OAuth2Claim>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/authorizationServers/{authServerId}/claims/{claimId}".expanded(using: [
+                        "authServerId": authServerId, 
+                        "claimId": claimId
+                    ]), method: "PUT", body: oAuth2Claim), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Replace a Custom Token Scope
          
          - parameter authServerId: (path)  
@@ -543,6 +1221,25 @@ public extension OktaClient {
                     "authServerId": authServerId, 
                     "scopeId": scopeId
                 ]), method: "PUT", body: oAuth2Scope))
+        }
+
+        /**
+         Replace a Custom Token Scope
+         
+         - parameter authServerId: (path)  
+         - parameter scopeId: (path)  
+         - parameter oAuth2Scope: (body)  
+         - parameter completion: Completion block
+         */
+        public func updateOAuth2Scope(authServerId: String, scopeId: String, oAuth2Scope: OAuth2Scope, completion: @escaping (Result<OktaResponse<OAuth2Scope>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/authorizationServers/{authServerId}/scopes/{scopeId}".expanded(using: [
+                        "authServerId": authServerId, 
+                        "scopeId": scopeId
+                    ]), method: "PUT", body: oAuth2Scope), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
     }

--- a/Sources/OktaSdk/ManagementAPI/OktaSdk/BehaviorAPI.swift
+++ b/Sources/OktaSdk/ManagementAPI/OktaSdk/BehaviorAPI.swift
@@ -37,12 +37,42 @@ public extension OktaClient {
         }
 
         /**
+         Activate a Behavior Detection Rule
+         
+         - parameter behaviorId: (path) id of the Behavior Detection Rule 
+         - parameter completion: Completion block
+         */
+        public func activateBehaviorDetectionRule(behaviorId: String, completion: @escaping (Result<OktaResponse<BehaviorRule>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/behaviors/{behaviorId}/lifecycle/activate".expanded(using: [
+                        "behaviorId": behaviorId
+                    ]), method: "POST"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Create a Behavior Detection Rule
          
          - parameter rule: (body)  
          */
         public func createBehaviorDetectionRule(rule: BehaviorRule) async throws -> OktaResponse<BehaviorRule> {
             try await send(try requestWithBody(to: "/api/v1/behaviors", method: "POST", body: rule))
+        }
+
+        /**
+         Create a Behavior Detection Rule
+         
+         - parameter rule: (body)  
+         - parameter completion: Completion block
+         */
+        public func createBehaviorDetectionRule(rule: BehaviorRule, completion: @escaping (Result<OktaResponse<BehaviorRule>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/behaviors", method: "POST", body: rule), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -54,6 +84,22 @@ public extension OktaClient {
             try await send(try request(to: "/api/v1/behaviors/{behaviorId}/lifecycle/deactivate".expanded(using: [
                     "behaviorId": behaviorId
                 ]), method: "POST"))
+        }
+
+        /**
+         Deactivate a Behavior Detection Rule
+         
+         - parameter behaviorId: (path) id of the Behavior Detection Rule 
+         - parameter completion: Completion block
+         */
+        public func deactivateBehaviorDetectionRule(behaviorId: String, completion: @escaping (Result<OktaResponse<BehaviorRule>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/behaviors/{behaviorId}/lifecycle/deactivate".expanded(using: [
+                        "behaviorId": behaviorId
+                    ]), method: "POST"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -69,6 +115,22 @@ public extension OktaClient {
         }
 
         /**
+         Delete a Behavior Detection Rule
+         
+         - parameter behaviorId: (path) id of the Behavior Detection Rule 
+         - parameter completion: Completion block
+         */
+        public func deleteBehaviorDetectionRule(behaviorId: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/behaviors/{behaviorId}".expanded(using: [
+                        "behaviorId": behaviorId
+                    ]), method: "DELETE"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Retrieve a Behavior Detection Rule
          
          - parameter behaviorId: (path) id of the Behavior Detection Rule 
@@ -80,11 +142,40 @@ public extension OktaClient {
         }
 
         /**
+         Retrieve a Behavior Detection Rule
+         
+         - parameter behaviorId: (path) id of the Behavior Detection Rule 
+         - parameter completion: Completion block
+         */
+        public func getBehaviorDetectionRule(behaviorId: String, completion: @escaping (Result<OktaResponse<[BehaviorRule]>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/behaviors/{behaviorId}".expanded(using: [
+                        "behaviorId": behaviorId
+                    ]), method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          List all Behavior Detection Rules
          
          */
         public func listBehaviorDetectionRules() async throws -> OktaResponse<[BehaviorRule]> {
             try await send(try request(to: "/api/v1/behaviors", method: "GET"))
+        }
+
+        /**
+         List all Behavior Detection Rules
+         
+         - parameter completion: Completion block
+         */
+        public func listBehaviorDetectionRules(completion: @escaping (Result<OktaResponse<[BehaviorRule]>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/behaviors", method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -97,6 +188,23 @@ public extension OktaClient {
             try await send(try requestWithBody(to: "/api/v1/behaviors/{behaviorId}".expanded(using: [
                     "behaviorId": behaviorId
                 ]), method: "PUT", body: rule))
+        }
+
+        /**
+         Replace a Behavior Detection Rule
+         
+         - parameter behaviorId: (path) id of the Behavior Detection Rule 
+         - parameter rule: (body)  
+         - parameter completion: Completion block
+         */
+        public func updateBehaviorDetectionRule(behaviorId: String, rule: BehaviorRule, completion: @escaping (Result<OktaResponse<BehaviorRule>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/behaviors/{behaviorId}".expanded(using: [
+                        "behaviorId": behaviorId
+                    ]), method: "PUT", body: rule), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
     }

--- a/Sources/OktaSdk/ManagementAPI/OktaSdk/CAPTCHAAPI.swift
+++ b/Sources/OktaSdk/ManagementAPI/OktaSdk/CAPTCHAAPI.swift
@@ -35,6 +35,20 @@ public extension OktaClient {
         }
 
         /**
+         Create a CAPTCHA instance
+         
+         - parameter instance: (body)  
+         - parameter completion: Completion block
+         */
+        public func createCaptchaInstance(instance: CAPTCHAInstance, completion: @escaping (Result<OktaResponse<CAPTCHAInstance>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/captchas", method: "POST", body: instance), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Delete a CAPTCHA Instance
          
          - parameter captchaId: (path) id of the CAPTCHA 
@@ -44,6 +58,22 @@ public extension OktaClient {
             try await send(try request(to: "/api/v1/captchas/{captchaId}".expanded(using: [
                     "captchaId": captchaId
                 ]), method: "DELETE"))
+        }
+
+        /**
+         Delete a CAPTCHA Instance
+         
+         - parameter captchaId: (path) id of the CAPTCHA 
+         - parameter completion: Completion block
+         */
+        public func deleteCaptchaInstance(captchaId: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/captchas/{captchaId}".expanded(using: [
+                        "captchaId": captchaId
+                    ]), method: "DELETE"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -58,11 +88,40 @@ public extension OktaClient {
         }
 
         /**
+         Retrieve a CAPTCHA Instance
+         
+         - parameter captchaId: (path) id of the CAPTCHA 
+         - parameter completion: Completion block
+         */
+        public func getCaptchaInstance(captchaId: String, completion: @escaping (Result<OktaResponse<CAPTCHAInstance>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/captchas/{captchaId}".expanded(using: [
+                        "captchaId": captchaId
+                    ]), method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          List all CAPTCHA instances
          
          */
         public func listCaptchaInstances() async throws -> OktaResponse<[CAPTCHAInstance]> {
             try await send(try request(to: "/api/v1/captchas", method: "GET"))
+        }
+
+        /**
+         List all CAPTCHA instances
+         
+         - parameter completion: Completion block
+         */
+        public func listCaptchaInstances(completion: @escaping (Result<OktaResponse<[CAPTCHAInstance]>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/captchas", method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -78,6 +137,23 @@ public extension OktaClient {
         }
 
         /**
+         Update a CAPTCHA instance
+         
+         - parameter captchaId: (path) id of the CAPTCHA 
+         - parameter instance: (body)  
+         - parameter completion: Completion block
+         */
+        public func partialUpdateCaptchaInstance(captchaId: String, instance: CAPTCHAInstance, completion: @escaping (Result<OktaResponse<CAPTCHAInstance>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/captchas/{captchaId}".expanded(using: [
+                        "captchaId": captchaId
+                    ]), method: "POST", body: instance), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Replace a CAPTCHA instance
          
          - parameter captchaId: (path) id of the CAPTCHA 
@@ -87,6 +163,23 @@ public extension OktaClient {
             try await send(try requestWithBody(to: "/api/v1/captchas/{captchaId}".expanded(using: [
                     "captchaId": captchaId
                 ]), method: "PUT", body: instance))
+        }
+
+        /**
+         Replace a CAPTCHA instance
+         
+         - parameter captchaId: (path) id of the CAPTCHA 
+         - parameter instance: (body)  
+         - parameter completion: Completion block
+         */
+        public func updateCaptchaInstance(captchaId: String, instance: CAPTCHAInstance, completion: @escaping (Result<OktaResponse<CAPTCHAInstance>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/captchas/{captchaId}".expanded(using: [
+                        "captchaId": captchaId
+                    ]), method: "PUT", body: instance), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
     }

--- a/Sources/OktaSdk/ManagementAPI/OktaSdk/CustomizationAPI.swift
+++ b/Sources/OktaSdk/ManagementAPI/OktaSdk/CustomizationAPI.swift
@@ -40,6 +40,25 @@ public extension OktaClient {
         }
 
         /**
+         Create an Email Customization
+         
+         - parameter brandId: (path) The ID of the brand. 
+         - parameter templateName: (path) The name of the email template. 
+         - parameter instance: (body)  (optional)
+         - parameter completion: Completion block
+         */
+        public func createEmailCustomization(brandId: String, templateName: String, instance: EmailCustomization? = nil, completion: @escaping (Result<OktaResponse<EmailCustomization>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/brands/{brandId}/templates/email/{templateName}/customizations".expanded(using: [
+                        "brandId": brandId, 
+                        "templateName": templateName
+                    ]), method: "POST", body: instance), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Delete all Email Customizations
          
          - parameter brandId: (path) The ID of the brand. 
@@ -51,6 +70,24 @@ public extension OktaClient {
                     "brandId": brandId, 
                     "templateName": templateName
                 ]), method: "DELETE"))
+        }
+
+        /**
+         Delete all Email Customizations
+         
+         - parameter brandId: (path) The ID of the brand. 
+         - parameter templateName: (path) The name of the email template. 
+         - parameter completion: Completion block
+         */
+        public func deleteAllCustomizations(brandId: String, templateName: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/brands/{brandId}/templates/email/{templateName}/customizations".expanded(using: [
+                        "brandId": brandId, 
+                        "templateName": templateName
+                    ]), method: "DELETE"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -68,6 +105,24 @@ public extension OktaClient {
         }
 
         /**
+         Delete the Background Image
+         
+         - parameter brandId: (path)  
+         - parameter themeId: (path)  
+         - parameter completion: Completion block
+         */
+        public func deleteBrandThemeBackgroundImage(brandId: String, themeId: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/brands/{brandId}/themes/{themeId}/background-image".expanded(using: [
+                        "brandId": brandId, 
+                        "themeId": themeId
+                    ]), method: "DELETE"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Delete the Favicon
          
          - parameter brandId: (path)  
@@ -82,6 +137,24 @@ public extension OktaClient {
         }
 
         /**
+         Delete the Favicon
+         
+         - parameter brandId: (path)  
+         - parameter themeId: (path)  
+         - parameter completion: Completion block
+         */
+        public func deleteBrandThemeFavicon(brandId: String, themeId: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/brands/{brandId}/themes/{themeId}/favicon".expanded(using: [
+                        "brandId": brandId, 
+                        "themeId": themeId
+                    ]), method: "DELETE"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Delete the Logo
          
          - parameter brandId: (path)  
@@ -93,6 +166,24 @@ public extension OktaClient {
                     "brandId": brandId, 
                     "themeId": themeId
                 ]), method: "DELETE"))
+        }
+
+        /**
+         Delete the Logo
+         
+         - parameter brandId: (path)  
+         - parameter themeId: (path)  
+         - parameter completion: Completion block
+         */
+        public func deleteBrandThemeLogo(brandId: String, themeId: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/brands/{brandId}/themes/{themeId}/logo".expanded(using: [
+                        "brandId": brandId, 
+                        "themeId": themeId
+                    ]), method: "DELETE"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -112,6 +203,26 @@ public extension OktaClient {
         }
 
         /**
+         Delete an Email Customization
+         
+         - parameter brandId: (path) The ID of the brand. 
+         - parameter templateName: (path) The name of the email template. 
+         - parameter customizationId: (path) The ID of the email customization. 
+         - parameter completion: Completion block
+         */
+        public func deleteEmailCustomization(brandId: String, templateName: String, customizationId: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/brands/{brandId}/templates/email/{templateName}/customizations/{customizationId}".expanded(using: [
+                        "brandId": brandId, 
+                        "templateName": templateName, 
+                        "customizationId": customizationId
+                    ]), method: "DELETE"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Retrieve a Brand
          
          - parameter brandId: (path)  
@@ -120,6 +231,22 @@ public extension OktaClient {
             try await send(try request(to: "/api/v1/brands/{brandId}".expanded(using: [
                     "brandId": brandId
                 ]), method: "GET"))
+        }
+
+        /**
+         Retrieve a Brand
+         
+         - parameter brandId: (path)  
+         - parameter completion: Completion block
+         */
+        public func getBrand(brandId: String, completion: @escaping (Result<OktaResponse<Brand>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/brands/{brandId}".expanded(using: [
+                        "brandId": brandId
+                    ]), method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -133,6 +260,24 @@ public extension OktaClient {
                     "brandId": brandId, 
                     "themeId": themeId
                 ]), method: "GET"))
+        }
+
+        /**
+         Retrieve a Theme
+         
+         - parameter brandId: (path)  
+         - parameter themeId: (path)  
+         - parameter completion: Completion block
+         */
+        public func getBrandTheme(brandId: String, themeId: String, completion: @escaping (Result<OktaResponse<ThemeResponse>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/brands/{brandId}/themes/{themeId}".expanded(using: [
+                        "brandId": brandId, 
+                        "themeId": themeId
+                    ]), method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -151,6 +296,26 @@ public extension OktaClient {
         }
 
         /**
+         Preview an Email Customization
+         
+         - parameter brandId: (path) The ID of the brand. 
+         - parameter templateName: (path) The name of the email template. 
+         - parameter customizationId: (path) The ID of the email customization. 
+         - parameter completion: Completion block
+         */
+        public func getCustomizationPreview(brandId: String, templateName: String, customizationId: String, completion: @escaping (Result<OktaResponse<EmailPreview>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/brands/{brandId}/templates/email/{templateName}/customizations/{customizationId}/preview".expanded(using: [
+                        "brandId": brandId, 
+                        "templateName": templateName, 
+                        "customizationId": customizationId
+                    ]), method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Retrieve an Email Customization
          
          - parameter brandId: (path) The ID of the brand. 
@@ -163,6 +328,26 @@ public extension OktaClient {
                     "templateName": templateName, 
                     "customizationId": customizationId
                 ]), method: "GET"))
+        }
+
+        /**
+         Retrieve an Email Customization
+         
+         - parameter brandId: (path) The ID of the brand. 
+         - parameter templateName: (path) The name of the email template. 
+         - parameter customizationId: (path) The ID of the email customization. 
+         - parameter completion: Completion block
+         */
+        public func getEmailCustomization(brandId: String, templateName: String, customizationId: String, completion: @escaping (Result<OktaResponse<EmailCustomization>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/brands/{brandId}/templates/email/{templateName}/customizations/{customizationId}".expanded(using: [
+                        "brandId": brandId, 
+                        "templateName": templateName, 
+                        "customizationId": customizationId
+                    ]), method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -182,6 +367,27 @@ public extension OktaClient {
         }
 
         /**
+         Retrieve an Email Template Default Content
+         
+         - parameter brandId: (path) The ID of the brand. 
+         - parameter templateName: (path) The name of the email template. 
+         - parameter language: (query) The language to use for the email. Defaults to the current user&#39;s language if unspecified. (optional)
+         - parameter completion: Completion block
+         */
+        public func getEmailDefaultContent(brandId: String, templateName: String, language: String? = nil, completion: @escaping (Result<OktaResponse<EmailDefaultContent>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/brands/{brandId}/templates/email/{templateName}/default-content".expanded(using: [
+                        "brandId": brandId, 
+                        "templateName": templateName
+                    ]), method: "GET", query: [
+                        "language": language
+                    ]), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Preview the Email Template Default Content
          
          - parameter brandId: (path) The ID of the brand. 
@@ -198,6 +404,27 @@ public extension OktaClient {
         }
 
         /**
+         Preview the Email Template Default Content
+         
+         - parameter brandId: (path) The ID of the brand. 
+         - parameter templateName: (path) The name of the email template. 
+         - parameter language: (query) The language to use for the email. Defaults to the current user&#39;s language if unspecified. (optional)
+         - parameter completion: Completion block
+         */
+        public func getEmailDefaultPreview(brandId: String, templateName: String, language: String? = nil, completion: @escaping (Result<OktaResponse<EmailPreview>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/brands/{brandId}/templates/email/{templateName}/default-content/preview".expanded(using: [
+                        "brandId": brandId, 
+                        "templateName": templateName
+                    ]), method: "GET", query: [
+                        "language": language
+                    ]), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Retrieve the Email Template Settings
          
          - parameter brandId: (path) The ID of the brand. 
@@ -208,6 +435,24 @@ public extension OktaClient {
                     "brandId": brandId, 
                     "templateName": templateName
                 ]), method: "GET"))
+        }
+
+        /**
+         Retrieve the Email Template Settings
+         
+         - parameter brandId: (path) The ID of the brand. 
+         - parameter templateName: (path) The name of the email template. 
+         - parameter completion: Completion block
+         */
+        public func getEmailSettings(brandId: String, templateName: String, completion: @escaping (Result<OktaResponse<EmailSettings>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/brands/{brandId}/templates/email/{templateName}/settings".expanded(using: [
+                        "brandId": brandId, 
+                        "templateName": templateName
+                    ]), method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -235,6 +480,27 @@ public extension OktaClient {
         }
 
         /**
+         Retrieve an Email Template
+         
+         - parameter brandId: (path) The ID of the brand. 
+         - parameter templateName: (path) The name of the email template. 
+         - parameter expand: (query) Specifies additional metadata to be included in the response. (optional)
+         - parameter completion: Completion block
+         */
+        public func getEmailTemplate(brandId: String, templateName: String, expand: [String]? = nil, completion: @escaping (Result<OktaResponse<EmailTemplate>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/brands/{brandId}/templates/email/{templateName}".expanded(using: [
+                        "brandId": brandId, 
+                        "templateName": templateName
+                    ]), method: "GET", query: [
+                        "expand": expand
+                    ]), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          List all Themes
          
          - parameter brandId: (path)  
@@ -246,11 +512,40 @@ public extension OktaClient {
         }
 
         /**
+         List all Themes
+         
+         - parameter brandId: (path)  
+         - parameter completion: Completion block
+         */
+        public func listBrandThemes(brandId: String, completion: @escaping (Result<OktaResponse<[ThemeResponse]>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/brands/{brandId}/themes".expanded(using: [
+                        "brandId": brandId
+                    ]), method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          List all Brands
          
          */
         public func listBrands() async throws -> OktaResponse<[Brand]> {
             try await send(try request(to: "/api/v1/brands", method: "GET"))
+        }
+
+        /**
+         List all Brands
+         
+         - parameter completion: Completion block
+         */
+        public func listBrands(completion: @escaping (Result<OktaResponse<[Brand]>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/brands", method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -269,6 +564,29 @@ public extension OktaClient {
                     "after": after, 
                     "limit": limit
                 ]))
+        }
+
+        /**
+         List all Email Customizations
+         
+         - parameter brandId: (path) The ID of the brand. 
+         - parameter templateName: (path) The name of the email template. 
+         - parameter after: (query) The cursor to use for pagination. It is an opaque string that specifies your current location in the list and is obtained from the &#x60;Link&#x60; response header. See [Pagination](https://developer.okta.com/docs/reference/core-okta-api/#pagination) for more information. (optional)
+         - parameter limit: (query) A limit on the number of objects to return. (optional, default to 20)
+         - parameter completion: Completion block
+         */
+        public func listEmailCustomizations(brandId: String, templateName: String, after: String? = nil, limit: Int? = nil, completion: @escaping (Result<OktaResponse<[EmailCustomization]>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/brands/{brandId}/templates/email/{templateName}/customizations".expanded(using: [
+                        "brandId": brandId, 
+                        "templateName": templateName
+                    ]), method: "GET", query: [
+                        "after": after, 
+                        "limit": limit
+                    ]), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -298,6 +616,29 @@ public extension OktaClient {
         }
 
         /**
+         List all Email Templates
+         
+         - parameter brandId: (path) The ID of the brand. 
+         - parameter after: (query) The cursor to use for pagination. It is an opaque string that specifies your current location in the list and is obtained from the &#x60;Link&#x60; response header. See [Pagination](https://developer.okta.com/docs/reference/core-okta-api/#pagination) for more information. (optional)
+         - parameter limit: (query) A limit on the number of objects to return. (optional, default to 20)
+         - parameter expand: (query) Specifies additional metadata to be included in the response. (optional)
+         - parameter completion: Completion block
+         */
+        public func listEmailTemplates(brandId: String, after: String? = nil, limit: Int? = nil, expand: [String]? = nil, completion: @escaping (Result<OktaResponse<[EmailTemplate]>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/brands/{brandId}/templates/email".expanded(using: [
+                        "brandId": brandId
+                    ]), method: "GET", query: [
+                        "after": after, 
+                        "limit": limit, 
+                        "expand": expand
+                    ]), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Preview the Error Page
          
          - parameter brandId: (path) The ID of the brand. 
@@ -307,6 +648,23 @@ public extension OktaClient {
             try await send(try requestWithBody(to: "/api/v1/brands/{brandId}/pages/error/preview".expanded(using: [
                     "brandId": brandId
                 ]), method: "POST", body: customizablePage))
+        }
+
+        /**
+         Preview the Error Page
+         
+         - parameter brandId: (path) The ID of the brand. 
+         - parameter customizablePage: (body)  
+         - parameter completion: Completion block
+         */
+        public func previewErrorPage(brandId: String, customizablePage: CustomizablePage, completion: @escaping (Result<OktaResponse<String>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/brands/{brandId}/pages/error/preview".expanded(using: [
+                        "brandId": brandId
+                    ]), method: "POST", body: customizablePage), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -322,6 +680,23 @@ public extension OktaClient {
         }
 
         /**
+         Preview the Sign-in Page.
+         
+         - parameter brandId: (path) The ID of the brand. 
+         - parameter signInPage: (body)  
+         - parameter completion: Completion block
+         */
+        public func previewSignInPage(brandId: String, signInPage: SignInPage, completion: @escaping (Result<OktaResponse<String>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/brands/{brandId}/pages/sign-in/preview".expanded(using: [
+                        "brandId": brandId
+                    ]), method: "POST", body: signInPage), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Replace the Error Page
          
          - parameter brandId: (path) The ID of the brand. 
@@ -331,6 +706,23 @@ public extension OktaClient {
             try await send(try requestWithBody(to: "/api/v1/brands/{brandId}/pages/error".expanded(using: [
                     "brandId": brandId
                 ]), method: "PUT", body: customizablePage))
+        }
+
+        /**
+         Replace the Error Page
+         
+         - parameter brandId: (path) The ID of the brand. 
+         - parameter customizablePage: (body)  
+         - parameter completion: Completion block
+         */
+        public func replaceErrorPage(brandId: String, customizablePage: CustomizablePage, completion: @escaping (Result<OktaResponse<CustomizablePage>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/brands/{brandId}/pages/error".expanded(using: [
+                        "brandId": brandId
+                    ]), method: "PUT", body: customizablePage), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -346,6 +738,23 @@ public extension OktaClient {
         }
 
         /**
+         Replace the Sign-in Page
+         
+         - parameter brandId: (path) The ID of the brand. 
+         - parameter signInPage: (body)  
+         - parameter completion: Completion block
+         */
+        public func replaceSignInPage(brandId: String, signInPage: SignInPage, completion: @escaping (Result<OktaResponse<SignInPage>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/brands/{brandId}/pages/sign-in".expanded(using: [
+                        "brandId": brandId
+                    ]), method: "PUT", body: signInPage), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Replace the Sign-out Page Settings
          
          - parameter brandId: (path) The ID of the brand. 
@@ -355,6 +764,23 @@ public extension OktaClient {
             try await send(try requestWithBody(to: "/api/v1/brands/{brandId}/pages/sign-out".expanded(using: [
                     "brandId": brandId
                 ]), method: "PUT", body: hostedPage))
+        }
+
+        /**
+         Replace the Sign-out Page Settings
+         
+         - parameter brandId: (path) The ID of the brand. 
+         - parameter hostedPage: (body)  
+         - parameter completion: Completion block
+         */
+        public func replaceSignOutPageSettings(brandId: String, hostedPage: HostedPage, completion: @escaping (Result<OktaResponse<HostedPage>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/brands/{brandId}/pages/sign-out".expanded(using: [
+                        "brandId": brandId
+                    ]), method: "PUT", body: hostedPage), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -370,6 +796,22 @@ public extension OktaClient {
         }
 
         /**
+         Reset the Error Page
+         
+         - parameter brandId: (path) The ID of the brand. 
+         - parameter completion: Completion block
+         */
+        public func resetErrorPage(brandId: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/brands/{brandId}/pages/error".expanded(using: [
+                        "brandId": brandId
+                    ]), method: "DELETE"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Reset the Sign-in Page
          
          - parameter brandId: (path) The ID of the brand. 
@@ -379,6 +821,22 @@ public extension OktaClient {
             try await send(try request(to: "/api/v1/brands/{brandId}/pages/sign-in".expanded(using: [
                     "brandId": brandId
                 ]), method: "DELETE"))
+        }
+
+        /**
+         Reset the Sign-in Page
+         
+         - parameter brandId: (path) The ID of the brand. 
+         - parameter completion: Completion block
+         */
+        public func resetSignInPage(brandId: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/brands/{brandId}/pages/sign-in".expanded(using: [
+                        "brandId": brandId
+                    ]), method: "DELETE"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -393,6 +851,22 @@ public extension OktaClient {
         }
 
         /**
+         Retrieve the Error Page
+         
+         - parameter brandId: (path) The ID of the brand. 
+         - parameter completion: Completion block
+         */
+        public func retrieveErrorPage(brandId: String, completion: @escaping (Result<OktaResponse<CustomizablePage>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/brands/{brandId}/pages/error".expanded(using: [
+                        "brandId": brandId
+                    ]), method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Retrieve the Sign-in Page
          
          - parameter brandId: (path) The ID of the brand. 
@@ -404,6 +878,22 @@ public extension OktaClient {
         }
 
         /**
+         Retrieve the Sign-in Page
+         
+         - parameter brandId: (path) The ID of the brand. 
+         - parameter completion: Completion block
+         */
+        public func retrieveSignInPage(brandId: String, completion: @escaping (Result<OktaResponse<SignInPage>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/brands/{brandId}/pages/sign-in".expanded(using: [
+                        "brandId": brandId
+                    ]), method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Retrieve the Sign-out Page Settings
          
          - parameter brandId: (path) The ID of the brand. 
@@ -412,6 +902,22 @@ public extension OktaClient {
             try await send(try request(to: "/api/v1/brands/{brandId}/pages/sign-out".expanded(using: [
                     "brandId": brandId
                 ]), method: "GET"))
+        }
+
+        /**
+         Retrieve the Sign-out Page Settings
+         
+         - parameter brandId: (path) The ID of the brand. 
+         - parameter completion: Completion block
+         */
+        public func retrieveSignOutPageSettings(brandId: String, completion: @escaping (Result<OktaResponse<HostedPage>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/brands/{brandId}/pages/sign-out".expanded(using: [
+                        "brandId": brandId
+                    ]), method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -432,6 +938,27 @@ public extension OktaClient {
         }
 
         /**
+         Send a Test Email
+         
+         - parameter brandId: (path) The ID of the brand. 
+         - parameter templateName: (path) The name of the email template. 
+         - parameter language: (query) The language to use for the email. Defaults to the current user&#39;s language if unspecified. (optional)
+         - parameter completion: Completion block
+         */
+        public func sendTestEmail(brandId: String, templateName: String, language: String? = nil, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/brands/{brandId}/templates/email/{templateName}/test".expanded(using: [
+                        "brandId": brandId, 
+                        "templateName": templateName
+                    ]), method: "POST", query: [
+                        "language": language
+                    ]), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Replace a Brand
          
          - parameter brandId: (path)  
@@ -441,6 +968,23 @@ public extension OktaClient {
             try await send(try requestWithBody(to: "/api/v1/brands/{brandId}".expanded(using: [
                     "brandId": brandId
                 ]), method: "PUT", body: brand))
+        }
+
+        /**
+         Replace a Brand
+         
+         - parameter brandId: (path)  
+         - parameter brand: (body)  
+         - parameter completion: Completion block
+         */
+        public func updateBrand(brandId: String, brand: Brand, completion: @escaping (Result<OktaResponse<Brand>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/brands/{brandId}".expanded(using: [
+                        "brandId": brandId
+                    ]), method: "PUT", body: brand), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -455,6 +999,25 @@ public extension OktaClient {
                     "brandId": brandId, 
                     "themeId": themeId
                 ]), method: "PUT", body: theme))
+        }
+
+        /**
+         Replace a Theme
+         
+         - parameter brandId: (path)  
+         - parameter themeId: (path)  
+         - parameter theme: (body)  
+         - parameter completion: Completion block
+         */
+        public func updateBrandTheme(brandId: String, themeId: String, theme: Theme, completion: @escaping (Result<OktaResponse<ThemeResponse>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/brands/{brandId}/themes/{themeId}".expanded(using: [
+                        "brandId": brandId, 
+                        "themeId": themeId
+                    ]), method: "PUT", body: theme), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -474,6 +1037,27 @@ public extension OktaClient {
         }
 
         /**
+         Replace an Email Customization
+         
+         - parameter brandId: (path) The ID of the brand. 
+         - parameter templateName: (path) The name of the email template. 
+         - parameter customizationId: (path) The ID of the email customization. 
+         - parameter instance: (body) Request (optional)
+         - parameter completion: Completion block
+         */
+        public func updateEmailCustomization(brandId: String, templateName: String, customizationId: String, instance: EmailCustomization? = nil, completion: @escaping (Result<OktaResponse<EmailCustomization>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/brands/{brandId}/templates/email/{templateName}/customizations/{customizationId}".expanded(using: [
+                        "brandId": brandId, 
+                        "templateName": templateName, 
+                        "customizationId": customizationId
+                    ]), method: "PUT", body: instance), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Replace the Email Template Settings
          
          - parameter brandId: (path) The ID of the brand. 
@@ -486,6 +1070,25 @@ public extension OktaClient {
                     "brandId": brandId, 
                     "templateName": templateName
                 ]), method: "PUT", body: emailSettings))
+        }
+
+        /**
+         Replace the Email Template Settings
+         
+         - parameter brandId: (path) The ID of the brand. 
+         - parameter templateName: (path) The name of the email template. 
+         - parameter emailSettings: (body)  (optional)
+         - parameter completion: Completion block
+         */
+        public func updateEmailSettings(brandId: String, templateName: String, emailSettings: EmailSettings? = nil, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/brands/{brandId}/templates/email/{templateName}/settings".expanded(using: [
+                        "brandId": brandId, 
+                        "templateName": templateName
+                    ]), method: "PUT", body: emailSettings), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -503,6 +1106,25 @@ public extension OktaClient {
         }
 
         /**
+         Upload the Background Image
+         
+         - parameter brandId: (path)  
+         - parameter themeId: (path)  
+         - parameter file: (form)  
+         - parameter completion: Completion block
+         */
+        public func uploadBrandThemeBackgroundImage(brandId: String, themeId: String, file: URL, completion: @escaping (Result<OktaResponse<ImageUploadResponse>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/brands/{brandId}/themes/{themeId}/background-image".expanded(using: [
+                        "brandId": brandId, 
+                        "themeId": themeId
+                    ]), method: "POST"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Upload the Favicon
          
          - parameter brandId: (path)  
@@ -517,6 +1139,25 @@ public extension OktaClient {
         }
 
         /**
+         Upload the Favicon
+         
+         - parameter brandId: (path)  
+         - parameter themeId: (path)  
+         - parameter file: (form)  
+         - parameter completion: Completion block
+         */
+        public func uploadBrandThemeFavicon(brandId: String, themeId: String, file: URL, completion: @escaping (Result<OktaResponse<ImageUploadResponse>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/brands/{brandId}/themes/{themeId}/favicon".expanded(using: [
+                        "brandId": brandId, 
+                        "themeId": themeId
+                    ]), method: "POST"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Upload the Logo
          
          - parameter brandId: (path)  
@@ -528,6 +1169,25 @@ public extension OktaClient {
                     "brandId": brandId, 
                     "themeId": themeId
                 ]), method: "POST"))
+        }
+
+        /**
+         Upload the Logo
+         
+         - parameter brandId: (path)  
+         - parameter themeId: (path)  
+         - parameter file: (form)  
+         - parameter completion: Completion block
+         */
+        public func uploadBrandThemeLogo(brandId: String, themeId: String, file: URL, completion: @escaping (Result<OktaResponse<ImageUploadResponse>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/brands/{brandId}/themes/{themeId}/logo".expanded(using: [
+                        "brandId": brandId, 
+                        "themeId": themeId
+                    ]), method: "POST"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
     }

--- a/Sources/OktaSdk/ManagementAPI/OktaSdk/DomainAPI.swift
+++ b/Sources/OktaSdk/ManagementAPI/OktaSdk/DomainAPI.swift
@@ -39,12 +39,43 @@ public extension OktaClient {
         }
 
         /**
+         Replace the Certificate
+         
+         - parameter domainId: (path)  
+         - parameter certificate: (body)  
+         - parameter completion: Completion block
+         */
+        public func createCertificate(domainId: String, certificate: DomainCertificate, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/domains/{domainId}/certificate".expanded(using: [
+                        "domainId": domainId
+                    ]), method: "PUT", body: certificate), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Create a Domain
          
          - parameter domain: (body)  
          */
         public func createDomain(domain: Domain) async throws -> OktaResponse<DomainResponse> {
             try await send(try requestWithBody(to: "/api/v1/domains", method: "POST", body: domain))
+        }
+
+        /**
+         Create a Domain
+         
+         - parameter domain: (body)  
+         - parameter completion: Completion block
+         */
+        public func createDomain(domain: Domain, completion: @escaping (Result<OktaResponse<DomainResponse>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/domains", method: "POST", body: domain), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -60,6 +91,22 @@ public extension OktaClient {
         }
 
         /**
+         Delete a Domain
+         
+         - parameter domainId: (path)  
+         - parameter completion: Completion block
+         */
+        public func deleteDomain(domainId: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/domains/{domainId}".expanded(using: [
+                        "domainId": domainId
+                    ]), method: "DELETE"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Retrieve a Domain
          
          - parameter domainId: (path)  
@@ -71,11 +118,40 @@ public extension OktaClient {
         }
 
         /**
+         Retrieve a Domain
+         
+         - parameter domainId: (path)  
+         - parameter completion: Completion block
+         */
+        public func getDomain(domainId: String, completion: @escaping (Result<OktaResponse<DomainResponse>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/domains/{domainId}".expanded(using: [
+                        "domainId": domainId
+                    ]), method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          List all Domains
          
          */
         public func listDomains() async throws -> OktaResponse<DomainListResponse> {
             try await send(try request(to: "/api/v1/domains", method: "GET"))
+        }
+
+        /**
+         List all Domains
+         
+         - parameter completion: Completion block
+         */
+        public func listDomains(completion: @escaping (Result<OktaResponse<DomainListResponse>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/domains", method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -87,6 +163,22 @@ public extension OktaClient {
             try await send(try request(to: "/api/v1/domains/{domainId}/verify".expanded(using: [
                     "domainId": domainId
                 ]), method: "POST"))
+        }
+
+        /**
+         Verify a Domain
+         
+         - parameter domainId: (path)  
+         - parameter completion: Completion block
+         */
+        public func verifyDomain(domainId: String, completion: @escaping (Result<OktaResponse<DomainResponse>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/domains/{domainId}/verify".expanded(using: [
+                        "domainId": domainId
+                    ]), method: "POST"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
     }

--- a/Sources/OktaSdk/ManagementAPI/OktaSdk/EventHookAPI.swift
+++ b/Sources/OktaSdk/ManagementAPI/OktaSdk/EventHookAPI.swift
@@ -37,12 +37,42 @@ public extension OktaClient {
         }
 
         /**
+         Activate an Event Hook
+         
+         - parameter eventHookId: (path)  
+         - parameter completion: Completion block
+         */
+        public func activateEventHook(eventHookId: String, completion: @escaping (Result<OktaResponse<EventHook>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/eventHooks/{eventHookId}/lifecycle/activate".expanded(using: [
+                        "eventHookId": eventHookId
+                    ]), method: "POST"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Create an Event Hook
          
          - parameter eventHook: (body)  
          */
         public func createEventHook(eventHook: EventHook) async throws -> OktaResponse<EventHook> {
             try await send(try requestWithBody(to: "/api/v1/eventHooks", method: "POST", body: eventHook))
+        }
+
+        /**
+         Create an Event Hook
+         
+         - parameter eventHook: (body)  
+         - parameter completion: Completion block
+         */
+        public func createEventHook(eventHook: EventHook, completion: @escaping (Result<OktaResponse<EventHook>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/eventHooks", method: "POST", body: eventHook), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -54,6 +84,22 @@ public extension OktaClient {
             try await send(try request(to: "/api/v1/eventHooks/{eventHookId}/lifecycle/deactivate".expanded(using: [
                     "eventHookId": eventHookId
                 ]), method: "POST"))
+        }
+
+        /**
+         Deactivate an Event Hook
+         
+         - parameter eventHookId: (path)  
+         - parameter completion: Completion block
+         */
+        public func deactivateEventHook(eventHookId: String, completion: @escaping (Result<OktaResponse<EventHook>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/eventHooks/{eventHookId}/lifecycle/deactivate".expanded(using: [
+                        "eventHookId": eventHookId
+                    ]), method: "POST"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -69,6 +115,22 @@ public extension OktaClient {
         }
 
         /**
+         Delete an Event Hook
+         
+         - parameter eventHookId: (path)  
+         - parameter completion: Completion block
+         */
+        public func deleteEventHook(eventHookId: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/eventHooks/{eventHookId}".expanded(using: [
+                        "eventHookId": eventHookId
+                    ]), method: "DELETE"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Retrieve an Event Hook
          
          - parameter eventHookId: (path)  
@@ -80,11 +142,40 @@ public extension OktaClient {
         }
 
         /**
+         Retrieve an Event Hook
+         
+         - parameter eventHookId: (path)  
+         - parameter completion: Completion block
+         */
+        public func getEventHook(eventHookId: String, completion: @escaping (Result<OktaResponse<EventHook>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/eventHooks/{eventHookId}".expanded(using: [
+                        "eventHookId": eventHookId
+                    ]), method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          List all Event Hooks
          
          */
         public func listEventHooks() async throws -> OktaResponse<[EventHook]> {
             try await send(try request(to: "/api/v1/eventHooks", method: "GET"))
+        }
+
+        /**
+         List all Event Hooks
+         
+         - parameter completion: Completion block
+         */
+        public func listEventHooks(completion: @escaping (Result<OktaResponse<[EventHook]>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/eventHooks", method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -100,6 +191,23 @@ public extension OktaClient {
         }
 
         /**
+         Replace an Event Hook
+         
+         - parameter eventHookId: (path)  
+         - parameter eventHook: (body)  
+         - parameter completion: Completion block
+         */
+        public func updateEventHook(eventHookId: String, eventHook: EventHook, completion: @escaping (Result<OktaResponse<EventHook>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/eventHooks/{eventHookId}".expanded(using: [
+                        "eventHookId": eventHookId
+                    ]), method: "PUT", body: eventHook), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Verify an Event Hook
          
          - parameter eventHookId: (path)  
@@ -108,6 +216,22 @@ public extension OktaClient {
             try await send(try request(to: "/api/v1/eventHooks/{eventHookId}/lifecycle/verify".expanded(using: [
                     "eventHookId": eventHookId
                 ]), method: "POST"))
+        }
+
+        /**
+         Verify an Event Hook
+         
+         - parameter eventHookId: (path)  
+         - parameter completion: Completion block
+         */
+        public func verifyEventHook(eventHookId: String, completion: @escaping (Result<OktaResponse<EventHook>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/eventHooks/{eventHookId}/lifecycle/verify".expanded(using: [
+                        "eventHookId": eventHookId
+                    ]), method: "POST"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
     }

--- a/Sources/OktaSdk/ManagementAPI/OktaSdk/FeatureAPI.swift
+++ b/Sources/OktaSdk/ManagementAPI/OktaSdk/FeatureAPI.swift
@@ -37,6 +37,22 @@ public extension OktaClient {
         }
 
         /**
+         Retrieve a Feature
+         
+         - parameter featureId: (path)  
+         - parameter completion: Completion block
+         */
+        public func getFeature(featureId: String, completion: @escaping (Result<OktaResponse<Feature>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/features/{featureId}".expanded(using: [
+                        "featureId": featureId
+                    ]), method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          List all Dependencies
          
          - parameter featureId: (path)  
@@ -45,6 +61,22 @@ public extension OktaClient {
             try await send(try request(to: "/api/v1/features/{featureId}/dependencies".expanded(using: [
                     "featureId": featureId
                 ]), method: "GET"))
+        }
+
+        /**
+         List all Dependencies
+         
+         - parameter featureId: (path)  
+         - parameter completion: Completion block
+         */
+        public func listFeatureDependencies(featureId: String, completion: @escaping (Result<OktaResponse<[Feature]>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/features/{featureId}/dependencies".expanded(using: [
+                        "featureId": featureId
+                    ]), method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -59,11 +91,40 @@ public extension OktaClient {
         }
 
         /**
+         List all Dependents
+         
+         - parameter featureId: (path)  
+         - parameter completion: Completion block
+         */
+        public func listFeatureDependents(featureId: String, completion: @escaping (Result<OktaResponse<[Feature]>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/features/{featureId}/dependents".expanded(using: [
+                        "featureId": featureId
+                    ]), method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          List all Features
          
          */
         public func listFeatures() async throws -> OktaResponse<[Feature]> {
             try await send(try request(to: "/api/v1/features", method: "GET"))
+        }
+
+        /**
+         List all Features
+         
+         - parameter completion: Completion block
+         */
+        public func listFeatures(completion: @escaping (Result<OktaResponse<[Feature]>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/features", method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -80,6 +141,27 @@ public extension OktaClient {
                 ]), method: "POST", query: [
                     "mode": mode
                 ]))
+        }
+
+        /**
+         Update a Feature Lifecycle
+         
+         - parameter featureId: (path)  
+         - parameter lifecycle: (path)  
+         - parameter mode: (query)  (optional)
+         - parameter completion: Completion block
+         */
+        public func updateFeatureLifecycle(featureId: String, lifecycle: String, mode: String? = nil, completion: @escaping (Result<OktaResponse<Feature>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/features/{featureId}/{lifecycle}".expanded(using: [
+                        "featureId": featureId, 
+                        "lifecycle": lifecycle
+                    ]), method: "POST", query: [
+                        "mode": mode
+                    ]), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
     }

--- a/Sources/OktaSdk/ManagementAPI/OktaSdk/GroupAPI.swift
+++ b/Sources/OktaSdk/ManagementAPI/OktaSdk/GroupAPI.swift
@@ -38,6 +38,22 @@ public extension OktaClient {
         }
 
         /**
+         Activate a Group Rule
+         
+         - parameter ruleId: (path)  
+         - parameter completion: Completion block
+         */
+        public func activateGroupRule(ruleId: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/groups/rules/{ruleId}/lifecycle/activate".expanded(using: [
+                        "ruleId": ruleId
+                    ]), method: "POST"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Assign an Application Instance Target to Application Administrator Role
          
          - parameter groupId: (path)  
@@ -53,6 +69,28 @@ public extension OktaClient {
                     "appName": appName, 
                     "applicationId": applicationId
                 ]), method: "PUT"))
+        }
+
+        /**
+         Assign an Application Instance Target to Application Administrator Role
+         
+         - parameter groupId: (path)  
+         - parameter roleId: (path)  
+         - parameter appName: (path)  
+         - parameter applicationId: (path)  
+         - parameter completion: Completion block
+         */
+        public func addApplicationInstanceTargetToAppAdminRoleGivenToGroup(groupId: String, roleId: String, appName: String, applicationId: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/groups/{groupId}/roles/{roleId}/targets/catalog/apps/{appName}/{applicationId}".expanded(using: [
+                        "groupId": groupId, 
+                        "roleId": roleId, 
+                        "appName": appName, 
+                        "applicationId": applicationId
+                    ]), method: "PUT"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -72,6 +110,26 @@ public extension OktaClient {
         }
 
         /**
+         Assign an Application Target to Administrator Role
+         
+         - parameter groupId: (path)  
+         - parameter roleId: (path)  
+         - parameter appName: (path)  
+         - parameter completion: Completion block
+         */
+        public func addApplicationTargetToAdminRoleGivenToGroup(groupId: String, roleId: String, appName: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/groups/{groupId}/roles/{roleId}/targets/catalog/apps/{appName}".expanded(using: [
+                        "groupId": groupId, 
+                        "roleId": roleId, 
+                        "appName": appName
+                    ]), method: "PUT"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Assign a Group Target for Group Role
          
          - parameter groupId: (path)  
@@ -88,6 +146,26 @@ public extension OktaClient {
         }
 
         /**
+         Assign a Group Target for Group Role
+         
+         - parameter groupId: (path)  
+         - parameter roleId: (path)  
+         - parameter targetGroupId: (path)  
+         - parameter completion: Completion block
+         */
+        public func addGroupTargetToGroupAdministratorRoleForGroup(groupId: String, roleId: String, targetGroupId: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/groups/{groupId}/roles/{roleId}/targets/groups/{targetGroupId}".expanded(using: [
+                        "groupId": groupId, 
+                        "roleId": roleId, 
+                        "targetGroupId": targetGroupId
+                    ]), method: "PUT"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Assign a User
          
          - parameter groupId: (path)  
@@ -99,6 +177,24 @@ public extension OktaClient {
                     "groupId": groupId, 
                     "userId": userId
                 ]), method: "PUT"))
+        }
+
+        /**
+         Assign a User
+         
+         - parameter groupId: (path)  
+         - parameter userId: (path)  
+         - parameter completion: Completion block
+         */
+        public func addUserToGroup(groupId: String, userId: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/groups/{groupId}/users/{userId}".expanded(using: [
+                        "groupId": groupId, 
+                        "userId": userId
+                    ]), method: "PUT"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -117,6 +213,26 @@ public extension OktaClient {
         }
 
         /**
+         Assign a Role
+         
+         - parameter groupId: (path)  
+         - parameter assignRoleRequest: (body)  
+         - parameter disableNotifications: (query)  (optional)
+         - parameter completion: Completion block
+         */
+        public func assignRoleToGroup(groupId: String, assignRoleRequest: AssignRoleRequest, disableNotifications: Bool? = nil, completion: @escaping (Result<OktaResponse<Role>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/groups/{groupId}/roles".expanded(using: [
+                        "groupId": groupId
+                    ]), method: "POST", query: [
+                        "disableNotifications": disableNotifications
+                    ], body: assignRoleRequest), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Create a Group
          
          - parameter group: (body)  
@@ -126,12 +242,40 @@ public extension OktaClient {
         }
 
         /**
+         Create a Group
+         
+         - parameter group: (body)  
+         - parameter completion: Completion block
+         */
+        public func createGroup(group: Group, completion: @escaping (Result<OktaResponse<Group>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/groups", method: "POST", body: group), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Create a Group Rule
          
          - parameter groupRule: (body)  
          */
         public func createGroupRule(groupRule: GroupRule) async throws -> OktaResponse<GroupRule> {
             try await send(try requestWithBody(to: "/api/v1/groups/rules", method: "POST", body: groupRule))
+        }
+
+        /**
+         Create a Group Rule
+         
+         - parameter groupRule: (body)  
+         - parameter completion: Completion block
+         */
+        public func createGroupRule(groupRule: GroupRule, completion: @escaping (Result<OktaResponse<GroupRule>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/groups/rules", method: "POST", body: groupRule), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -147,6 +291,22 @@ public extension OktaClient {
         }
 
         /**
+         Deactivate a Group Rule
+         
+         - parameter ruleId: (path)  
+         - parameter completion: Completion block
+         */
+        public func deactivateGroupRule(ruleId: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/groups/rules/{ruleId}/lifecycle/deactivate".expanded(using: [
+                        "ruleId": ruleId
+                    ]), method: "POST"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Delete a Group
          
          - parameter groupId: (path)  
@@ -156,6 +316,22 @@ public extension OktaClient {
             try await send(try request(to: "/api/v1/groups/{groupId}".expanded(using: [
                     "groupId": groupId
                 ]), method: "DELETE"))
+        }
+
+        /**
+         Delete a Group
+         
+         - parameter groupId: (path)  
+         - parameter completion: Completion block
+         */
+        public func deleteGroup(groupId: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/groups/{groupId}".expanded(using: [
+                        "groupId": groupId
+                    ]), method: "DELETE"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -174,6 +350,25 @@ public extension OktaClient {
         }
 
         /**
+         Delete a group Rule
+         
+         - parameter ruleId: (path)  
+         - parameter removeUsers: (query) Indicates whether to keep or remove users from groups assigned by this rule. (optional)
+         - parameter completion: Completion block
+         */
+        public func deleteGroupRule(ruleId: String, removeUsers: Bool? = nil, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/groups/rules/{ruleId}".expanded(using: [
+                        "ruleId": ruleId
+                    ]), method: "DELETE", query: [
+                        "removeUsers": removeUsers
+                    ]), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          List all Group Rules
          
          - parameter groupId: (path)  
@@ -182,6 +377,22 @@ public extension OktaClient {
             try await send(try request(to: "/api/v1/groups/{groupId}".expanded(using: [
                     "groupId": groupId
                 ]), method: "GET"))
+        }
+
+        /**
+         List all Group Rules
+         
+         - parameter groupId: (path)  
+         - parameter completion: Completion block
+         */
+        public func getGroup(groupId: String, completion: @escaping (Result<OktaResponse<Group>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/groups/{groupId}".expanded(using: [
+                        "groupId": groupId
+                    ]), method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -199,6 +410,25 @@ public extension OktaClient {
         }
 
         /**
+         Retrieve a Group Rule
+         
+         - parameter ruleId: (path)  
+         - parameter expand: (query)  (optional)
+         - parameter completion: Completion block
+         */
+        public func getGroupRule(ruleId: String, expand: String? = nil, completion: @escaping (Result<OktaResponse<GroupRule>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/groups/rules/{ruleId}".expanded(using: [
+                        "ruleId": ruleId
+                    ]), method: "GET", query: [
+                        "expand": expand
+                    ]), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Retrieve a Role
          
          - parameter groupId: (path)  
@@ -209,6 +439,24 @@ public extension OktaClient {
                     "groupId": groupId, 
                     "roleId": roleId
                 ]), method: "GET"))
+        }
+
+        /**
+         Retrieve a Role
+         
+         - parameter groupId: (path)  
+         - parameter roleId: (path)  
+         - parameter completion: Completion block
+         */
+        public func getRole(groupId: String, roleId: String, completion: @escaping (Result<OktaResponse<Role>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/groups/{groupId}/roles/{roleId}".expanded(using: [
+                        "groupId": groupId, 
+                        "roleId": roleId
+                    ]), method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -230,6 +478,29 @@ public extension OktaClient {
         }
 
         /**
+         List all Application Targets for an Application Administrator Role
+         
+         - parameter groupId: (path)  
+         - parameter roleId: (path)  
+         - parameter after: (query)  (optional)
+         - parameter limit: (query)  (optional, default to 20)
+         - parameter completion: Completion block
+         */
+        public func listApplicationTargetsForApplicationAdministratorRoleForGroup(groupId: String, roleId: String, after: String? = nil, limit: Int? = nil, completion: @escaping (Result<OktaResponse<[CatalogApplication]>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/groups/{groupId}/roles/{roleId}/targets/catalog/apps".expanded(using: [
+                        "groupId": groupId, 
+                        "roleId": roleId
+                    ]), method: "GET", query: [
+                        "after": after, 
+                        "limit": limit
+                    ]), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          List all Assigned Applications
          
          - parameter groupId: (path)  
@@ -243,6 +514,27 @@ public extension OktaClient {
                     "after": after, 
                     "limit": limit
                 ]))
+        }
+
+        /**
+         List all Assigned Applications
+         
+         - parameter groupId: (path)  
+         - parameter after: (query) Specifies the pagination cursor for the next page of apps (optional)
+         - parameter limit: (query) Specifies the number of app results for a page (optional, default to 20)
+         - parameter completion: Completion block
+         */
+        public func listAssignedApplicationsForGroup(groupId: String, after: String? = nil, limit: Int? = nil, completion: @escaping (Result<OktaResponse<[Application]>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/groups/{groupId}/apps".expanded(using: [
+                        "groupId": groupId
+                    ]), method: "GET", query: [
+                        "after": after, 
+                        "limit": limit
+                    ]), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -260,6 +552,25 @@ public extension OktaClient {
         }
 
         /**
+         List all Assigned Roles
+         
+         - parameter groupId: (path)  
+         - parameter expand: (query)  (optional)
+         - parameter completion: Completion block
+         */
+        public func listGroupAssignedRoles(groupId: String, expand: String? = nil, completion: @escaping (Result<OktaResponse<[Role]>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/groups/{groupId}/roles".expanded(using: [
+                        "groupId": groupId
+                    ]), method: "GET", query: [
+                        "expand": expand
+                    ]), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          List all Group Rules
          
          - parameter limit: (query) Specifies the number of rule results in a page (optional, default to 50)
@@ -274,6 +585,28 @@ public extension OktaClient {
                     "search": search, 
                     "expand": expand
                 ]))
+        }
+
+        /**
+         List all Group Rules
+         
+         - parameter limit: (query) Specifies the number of rule results in a page (optional, default to 50)
+         - parameter after: (query) Specifies the pagination cursor for the next page of rules (optional)
+         - parameter search: (query) Specifies the keyword to search fules for (optional)
+         - parameter expand: (query) If specified as &#x60;groupIdToGroupNameMap&#x60;, then show group names (optional)
+         - parameter completion: Completion block
+         */
+        public func listGroupRules(limit: Int? = nil, after: String? = nil, search: String? = nil, expand: String? = nil, completion: @escaping (Result<OktaResponse<[GroupRule]>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/groups/rules", method: "GET", query: [
+                        "limit": limit, 
+                        "after": after, 
+                        "search": search, 
+                        "expand": expand
+                    ]), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -295,6 +628,29 @@ public extension OktaClient {
         }
 
         /**
+         List all Group Targets for a Group Role
+         
+         - parameter groupId: (path)  
+         - parameter roleId: (path)  
+         - parameter after: (query)  (optional)
+         - parameter limit: (query)  (optional, default to 20)
+         - parameter completion: Completion block
+         */
+        public func listGroupTargetsForGroupRole(groupId: String, roleId: String, after: String? = nil, limit: Int? = nil, completion: @escaping (Result<OktaResponse<[Group]>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/groups/{groupId}/roles/{roleId}/targets/groups".expanded(using: [
+                        "groupId": groupId, 
+                        "roleId": roleId
+                    ]), method: "GET", query: [
+                        "after": after, 
+                        "limit": limit
+                    ]), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          List all Member Users
          
          - parameter groupId: (path)  
@@ -308,6 +664,27 @@ public extension OktaClient {
                     "after": after, 
                     "limit": limit
                 ]))
+        }
+
+        /**
+         List all Member Users
+         
+         - parameter groupId: (path)  
+         - parameter after: (query) Specifies the pagination cursor for the next page of users (optional)
+         - parameter limit: (query) Specifies the number of user results in a page (optional, default to 1000)
+         - parameter completion: Completion block
+         */
+        public func listGroupUsers(groupId: String, after: String? = nil, limit: Int? = nil, completion: @escaping (Result<OktaResponse<[User]>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/groups/{groupId}/users".expanded(using: [
+                        "groupId": groupId
+                    ]), method: "GET", query: [
+                        "after": after, 
+                        "limit": limit
+                    ]), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -330,6 +707,30 @@ public extension OktaClient {
         }
 
         /**
+         List all Groups
+         
+         - parameter q: (query) Searches the name property of groups for matching value (optional)
+         - parameter search: (query) Filter expression for groups (optional)
+         - parameter after: (query) Specifies the pagination cursor for the next page of groups (optional)
+         - parameter limit: (query) Specifies the number of group results in a page (optional, default to 10000)
+         - parameter expand: (query) If specified, it causes additional metadata to be included in the response. (optional)
+         - parameter completion: Completion block
+         */
+        public func listGroups(q: String? = nil, search: String? = nil, after: String? = nil, limit: Int? = nil, expand: String? = nil, completion: @escaping (Result<OktaResponse<[Group]>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/groups", method: "GET", query: [
+                        "q": q, 
+                        "search": search, 
+                        "after": after, 
+                        "limit": limit, 
+                        "expand": expand
+                    ]), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Delete an Application Instance Target to Application Administrator Role
          
          - parameter groupId: (path)  
@@ -345,6 +746,28 @@ public extension OktaClient {
                     "appName": appName, 
                     "applicationId": applicationId
                 ]), method: "DELETE"))
+        }
+
+        /**
+         Delete an Application Instance Target to Application Administrator Role
+         
+         - parameter groupId: (path)  
+         - parameter roleId: (path)  
+         - parameter appName: (path)  
+         - parameter applicationId: (path)  
+         - parameter completion: Completion block
+         */
+        public func removeApplicationTargetFromAdministratorRoleGivenToGroup(groupId: String, roleId: String, appName: String, applicationId: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/groups/{groupId}/roles/{roleId}/targets/catalog/apps/{appName}/{applicationId}".expanded(using: [
+                        "groupId": groupId, 
+                        "roleId": roleId, 
+                        "appName": appName, 
+                        "applicationId": applicationId
+                    ]), method: "DELETE"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -364,6 +787,26 @@ public extension OktaClient {
         }
 
         /**
+         Delete an Application Target from Application Administrator Role
+         
+         - parameter groupId: (path)  
+         - parameter roleId: (path)  
+         - parameter appName: (path)  
+         - parameter completion: Completion block
+         */
+        public func removeApplicationTargetFromApplicationAdministratorRoleGivenToGroup(groupId: String, roleId: String, appName: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/groups/{groupId}/roles/{roleId}/targets/catalog/apps/{appName}".expanded(using: [
+                        "groupId": groupId, 
+                        "roleId": roleId, 
+                        "appName": appName
+                    ]), method: "DELETE"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Delete a Group Target for Group Role
          
          - parameter groupId: (path)  
@@ -377,6 +820,26 @@ public extension OktaClient {
                     "roleId": roleId, 
                     "targetGroupId": targetGroupId
                 ]), method: "DELETE"))
+        }
+
+        /**
+         Delete a Group Target for Group Role
+         
+         - parameter groupId: (path)  
+         - parameter roleId: (path)  
+         - parameter targetGroupId: (path)  
+         - parameter completion: Completion block
+         */
+        public func removeGroupTargetFromGroupAdministratorRoleGivenToGroup(groupId: String, roleId: String, targetGroupId: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/groups/{groupId}/roles/{roleId}/targets/groups/{targetGroupId}".expanded(using: [
+                        "groupId": groupId, 
+                        "roleId": roleId, 
+                        "targetGroupId": targetGroupId
+                    ]), method: "DELETE"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -394,6 +857,24 @@ public extension OktaClient {
         }
 
         /**
+         Delete a Role
+         
+         - parameter groupId: (path)  
+         - parameter roleId: (path)  
+         - parameter completion: Completion block
+         */
+        public func removeRoleFromGroup(groupId: String, roleId: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/groups/{groupId}/roles/{roleId}".expanded(using: [
+                        "groupId": groupId, 
+                        "roleId": roleId
+                    ]), method: "DELETE"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Unassign a User
          
          - parameter groupId: (path)  
@@ -405,6 +886,24 @@ public extension OktaClient {
                     "groupId": groupId, 
                     "userId": userId
                 ]), method: "DELETE"))
+        }
+
+        /**
+         Unassign a User
+         
+         - parameter groupId: (path)  
+         - parameter userId: (path)  
+         - parameter completion: Completion block
+         */
+        public func removeUserFromGroup(groupId: String, userId: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/groups/{groupId}/users/{userId}".expanded(using: [
+                        "groupId": groupId, 
+                        "userId": userId
+                    ]), method: "DELETE"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -420,6 +919,23 @@ public extension OktaClient {
         }
 
         /**
+         Replace a Group
+         
+         - parameter groupId: (path)  
+         - parameter group: (body)  
+         - parameter completion: Completion block
+         */
+        public func updateGroup(groupId: String, group: Group, completion: @escaping (Result<OktaResponse<Group>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/groups/{groupId}".expanded(using: [
+                        "groupId": groupId
+                    ]), method: "PUT", body: group), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Replace a Group Rule
          
          - parameter ruleId: (path)  
@@ -429,6 +945,23 @@ public extension OktaClient {
             try await send(try requestWithBody(to: "/api/v1/groups/rules/{ruleId}".expanded(using: [
                     "ruleId": ruleId
                 ]), method: "PUT", body: groupRule))
+        }
+
+        /**
+         Replace a Group Rule
+         
+         - parameter ruleId: (path)  
+         - parameter groupRule: (body)  
+         - parameter completion: Completion block
+         */
+        public func updateGroupRule(ruleId: String, groupRule: GroupRule, completion: @escaping (Result<OktaResponse<GroupRule>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/groups/rules/{ruleId}".expanded(using: [
+                        "ruleId": ruleId
+                    ]), method: "PUT", body: groupRule), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
     }

--- a/Sources/OktaSdk/ManagementAPI/OktaSdk/IdentityProviderAPI.swift
+++ b/Sources/OktaSdk/ManagementAPI/OktaSdk/IdentityProviderAPI.swift
@@ -37,6 +37,22 @@ public extension OktaClient {
         }
 
         /**
+         Activate an Identity Provider
+         
+         - parameter idpId: (path)  
+         - parameter completion: Completion block
+         */
+        public func activateIdentityProvider(idpId: String, completion: @escaping (Result<OktaResponse<IdentityProvider>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/idps/{idpId}/lifecycle/activate".expanded(using: [
+                        "idpId": idpId
+                    ]), method: "POST"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Clone a Signing Credential Key
          
          - parameter idpId: (path)  
@@ -53,12 +69,47 @@ public extension OktaClient {
         }
 
         /**
+         Clone a Signing Credential Key
+         
+         - parameter idpId: (path)  
+         - parameter keyId: (path)  
+         - parameter targetIdpId: (query)  
+         - parameter completion: Completion block
+         */
+        public func cloneIdentityProviderKey(idpId: String, keyId: String, targetIdpId: String, completion: @escaping (Result<OktaResponse<JsonWebKey>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/idps/{idpId}/credentials/keys/{keyId}/clone".expanded(using: [
+                        "idpId": idpId, 
+                        "keyId": keyId
+                    ]), method: "POST", query: [
+                        "targetIdpId": targetIdpId
+                    ]), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Create an Identity Provider
          
          - parameter identityProvider: (body)  
          */
         public func createIdentityProvider(identityProvider: IdentityProvider) async throws -> OktaResponse<IdentityProvider> {
             try await send(try requestWithBody(to: "/api/v1/idps", method: "POST", body: identityProvider))
+        }
+
+        /**
+         Create an Identity Provider
+         
+         - parameter identityProvider: (body)  
+         - parameter completion: Completion block
+         */
+        public func createIdentityProvider(identityProvider: IdentityProvider, completion: @escaping (Result<OktaResponse<IdentityProvider>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/idps", method: "POST", body: identityProvider), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -71,6 +122,20 @@ public extension OktaClient {
         }
 
         /**
+         Create an X.509 Certificate Public Key
+         
+         - parameter jsonWebKey: (body)  
+         - parameter completion: Completion block
+         */
+        public func createIdentityProviderKey(jsonWebKey: JsonWebKey, completion: @escaping (Result<OktaResponse<JsonWebKey>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/idps/credentials/keys", method: "POST", body: jsonWebKey), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Deactivate an Identity Provider
          
          - parameter idpId: (path)  
@@ -79,6 +144,22 @@ public extension OktaClient {
             try await send(try request(to: "/api/v1/idps/{idpId}/lifecycle/deactivate".expanded(using: [
                     "idpId": idpId
                 ]), method: "POST"))
+        }
+
+        /**
+         Deactivate an Identity Provider
+         
+         - parameter idpId: (path)  
+         - parameter completion: Completion block
+         */
+        public func deactivateIdentityProvider(idpId: String, completion: @escaping (Result<OktaResponse<IdentityProvider>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/idps/{idpId}/lifecycle/deactivate".expanded(using: [
+                        "idpId": idpId
+                    ]), method: "POST"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -94,6 +175,22 @@ public extension OktaClient {
         }
 
         /**
+         Delete an Identity Provider
+         
+         - parameter idpId: (path)  
+         - parameter completion: Completion block
+         */
+        public func deleteIdentityProvider(idpId: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/idps/{idpId}".expanded(using: [
+                        "idpId": idpId
+                    ]), method: "DELETE"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Delete a Signing Credential Key
          
          - parameter keyId: (path)  
@@ -106,6 +203,22 @@ public extension OktaClient {
         }
 
         /**
+         Delete a Signing Credential Key
+         
+         - parameter keyId: (path)  
+         - parameter completion: Completion block
+         */
+        public func deleteIdentityProviderKey(keyId: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/idps/credentials/keys/{keyId}".expanded(using: [
+                        "keyId": keyId
+                    ]), method: "DELETE"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Generate a Certificate Signing Request
          
          - parameter idpId: (path)  
@@ -115,6 +228,23 @@ public extension OktaClient {
             try await send(try requestWithBody(to: "/api/v1/idps/{idpId}/credentials/csrs".expanded(using: [
                     "idpId": idpId
                 ]), method: "POST", body: metadata))
+        }
+
+        /**
+         Generate a Certificate Signing Request
+         
+         - parameter idpId: (path)  
+         - parameter metadata: (body)  
+         - parameter completion: Completion block
+         */
+        public func generateCsrForIdentityProvider(idpId: String, metadata: CsrMetadata, completion: @escaping (Result<OktaResponse<Csr>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/idps/{idpId}/credentials/csrs".expanded(using: [
+                        "idpId": idpId
+                    ]), method: "POST", body: metadata), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -132,6 +262,25 @@ public extension OktaClient {
         }
 
         /**
+         Generate a new Signing Credential Key
+         
+         - parameter idpId: (path)  
+         - parameter validityYears: (query) expiry of the IdP Key Credential 
+         - parameter completion: Completion block
+         */
+        public func generateIdentityProviderSigningKey(idpId: String, validityYears: Int, completion: @escaping (Result<OktaResponse<JsonWebKey>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/idps/{idpId}/credentials/keys/generate".expanded(using: [
+                        "idpId": idpId
+                    ]), method: "POST", query: [
+                        "validityYears": validityYears
+                    ]), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Retrieve a Certificate Signing Request
          
          - parameter idpId: (path)  
@@ -145,6 +294,24 @@ public extension OktaClient {
         }
 
         /**
+         Retrieve a Certificate Signing Request
+         
+         - parameter idpId: (path)  
+         - parameter csrId: (path)  
+         - parameter completion: Completion block
+         */
+        public func getCsrForIdentityProvider(idpId: String, csrId: String, completion: @escaping (Result<OktaResponse<Csr>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/idps/{idpId}/credentials/csrs/{csrId}".expanded(using: [
+                        "idpId": idpId, 
+                        "csrId": csrId
+                    ]), method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Retrieve an Identity Provider
          
          - parameter idpId: (path)  
@@ -153,6 +320,22 @@ public extension OktaClient {
             try await send(try request(to: "/api/v1/idps/{idpId}".expanded(using: [
                     "idpId": idpId
                 ]), method: "GET"))
+        }
+
+        /**
+         Retrieve an Identity Provider
+         
+         - parameter idpId: (path)  
+         - parameter completion: Completion block
+         */
+        public func getIdentityProvider(idpId: String, completion: @escaping (Result<OktaResponse<IdentityProvider>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/idps/{idpId}".expanded(using: [
+                        "idpId": idpId
+                    ]), method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -169,6 +352,24 @@ public extension OktaClient {
         }
 
         /**
+         Retrieve a User
+         
+         - parameter idpId: (path)  
+         - parameter userId: (path)  
+         - parameter completion: Completion block
+         */
+        public func getIdentityProviderApplicationUser(idpId: String, userId: String, completion: @escaping (Result<OktaResponse<IdentityProviderApplicationUser>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/idps/{idpId}/users/{userId}".expanded(using: [
+                        "idpId": idpId, 
+                        "userId": userId
+                    ]), method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Retrieve an Credential Key
          
          - parameter keyId: (path)  
@@ -177,6 +378,22 @@ public extension OktaClient {
             try await send(try request(to: "/api/v1/idps/credentials/keys/{keyId}".expanded(using: [
                     "keyId": keyId
                 ]), method: "GET"))
+        }
+
+        /**
+         Retrieve an Credential Key
+         
+         - parameter keyId: (path)  
+         - parameter completion: Completion block
+         */
+        public func getIdentityProviderKey(keyId: String, completion: @escaping (Result<OktaResponse<JsonWebKey>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/idps/credentials/keys/{keyId}".expanded(using: [
+                        "keyId": keyId
+                    ]), method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -190,6 +407,24 @@ public extension OktaClient {
                     "idpId": idpId, 
                     "keyId": keyId
                 ]), method: "GET"))
+        }
+
+        /**
+         Retrieve a Signing Credential Key
+         
+         - parameter idpId: (path)  
+         - parameter keyId: (path)  
+         - parameter completion: Completion block
+         */
+        public func getIdentityProviderSigningKey(idpId: String, keyId: String, completion: @escaping (Result<OktaResponse<JsonWebKey>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/idps/{idpId}/credentials/keys/{keyId}".expanded(using: [
+                        "idpId": idpId, 
+                        "keyId": keyId
+                    ]), method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -207,6 +442,25 @@ public extension OktaClient {
         }
 
         /**
+         Link a User to a Social IdP
+         
+         - parameter idpId: (path)  
+         - parameter userId: (path)  
+         - parameter userIdentityProviderLinkRequest: (body)  
+         - parameter completion: Completion block
+         */
+        public func linkUserToIdentityProvider(idpId: String, userId: String, userIdentityProviderLinkRequest: UserIdentityProviderLinkRequest, completion: @escaping (Result<OktaResponse<IdentityProviderApplicationUser>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/idps/{idpId}/users/{userId}".expanded(using: [
+                        "idpId": idpId, 
+                        "userId": userId
+                    ]), method: "POST", body: userIdentityProviderLinkRequest), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          List all Certificate Signing Requests
          
          - parameter idpId: (path)  
@@ -218,6 +472,22 @@ public extension OktaClient {
         }
 
         /**
+         List all Certificate Signing Requests
+         
+         - parameter idpId: (path)  
+         - parameter completion: Completion block
+         */
+        public func listCsrsForIdentityProvider(idpId: String, completion: @escaping (Result<OktaResponse<[Csr]>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/idps/{idpId}/credentials/csrs".expanded(using: [
+                        "idpId": idpId
+                    ]), method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          List all Users
          
          - parameter idpId: (path)  
@@ -226,6 +496,22 @@ public extension OktaClient {
             try await send(try request(to: "/api/v1/idps/{idpId}/users".expanded(using: [
                     "idpId": idpId
                 ]), method: "GET"))
+        }
+
+        /**
+         List all Users
+         
+         - parameter idpId: (path)  
+         - parameter completion: Completion block
+         */
+        public func listIdentityProviderApplicationUsers(idpId: String, completion: @escaping (Result<OktaResponse<[IdentityProviderApplicationUser]>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/idps/{idpId}/users".expanded(using: [
+                        "idpId": idpId
+                    ]), method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -242,6 +528,24 @@ public extension OktaClient {
         }
 
         /**
+         List all Credential Keys
+         
+         - parameter after: (query) Specifies the pagination cursor for the next page of keys (optional)
+         - parameter limit: (query) Specifies the number of key results in a page (optional, default to 20)
+         - parameter completion: Completion block
+         */
+        public func listIdentityProviderKeys(after: String? = nil, limit: Int? = nil, completion: @escaping (Result<OktaResponse<[JsonWebKey]>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/idps/credentials/keys", method: "GET", query: [
+                        "after": after, 
+                        "limit": limit
+                    ]), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          List all Signing Credential Keys
          
          - parameter idpId: (path)  
@@ -250,6 +554,22 @@ public extension OktaClient {
             try await send(try request(to: "/api/v1/idps/{idpId}/credentials/keys".expanded(using: [
                     "idpId": idpId
                 ]), method: "GET"))
+        }
+
+        /**
+         List all Signing Credential Keys
+         
+         - parameter idpId: (path)  
+         - parameter completion: Completion block
+         */
+        public func listIdentityProviderSigningKeys(idpId: String, completion: @escaping (Result<OktaResponse<[JsonWebKey]>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/idps/{idpId}/credentials/keys".expanded(using: [
+                        "idpId": idpId
+                    ]), method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -270,6 +590,28 @@ public extension OktaClient {
         }
 
         /**
+         List all Identity Providers
+         
+         - parameter q: (query) Searches the name property of IdPs for matching value (optional)
+         - parameter after: (query) Specifies the pagination cursor for the next page of IdPs (optional)
+         - parameter limit: (query) Specifies the number of IdP results in a page (optional, default to 20)
+         - parameter type: (query) Filters IdPs by type (optional)
+         - parameter completion: Completion block
+         */
+        public func listIdentityProviders(q: String? = nil, after: String? = nil, limit: Int? = nil, type: String? = nil, completion: @escaping (Result<OktaResponse<[IdentityProvider]>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/idps", method: "GET", query: [
+                        "q": q, 
+                        "after": after, 
+                        "limit": limit, 
+                        "type": type
+                    ]), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          List all Tokens from a OIDC Identity Provider
          
          - parameter idpId: (path)  
@@ -280,6 +622,24 @@ public extension OktaClient {
                     "idpId": idpId, 
                     "userId": userId
                 ]), method: "GET"))
+        }
+
+        /**
+         List all Tokens from a OIDC Identity Provider
+         
+         - parameter idpId: (path)  
+         - parameter userId: (path)  
+         - parameter completion: Completion block
+         */
+        public func listSocialAuthTokens(idpId: String, userId: String, completion: @escaping (Result<OktaResponse<[SocialAuthToken]>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/idps/{idpId}/users/{userId}/credentials/tokens".expanded(using: [
+                        "idpId": idpId, 
+                        "userId": userId
+                    ]), method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -297,6 +657,25 @@ public extension OktaClient {
         }
 
         /**
+         Publish a Certificate Signing Request
+         
+         - parameter idpId: (path)  
+         - parameter csrId: (path)  
+         - parameter body: (body)  
+         - parameter completion: Completion block
+         */
+        public func publishCsrForIdentityProvider(idpId: String, csrId: String, body: URL, completion: @escaping (Result<OktaResponse<JsonWebKey>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/idps/{idpId}/credentials/csrs/{csrId}/lifecycle/publish".expanded(using: [
+                        "idpId": idpId, 
+                        "csrId": csrId
+                    ]), method: "POST", body: body), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Revoke a Certificate Signing Request
          
          - parameter idpId: (path)  
@@ -308,6 +687,24 @@ public extension OktaClient {
                     "idpId": idpId, 
                     "csrId": csrId
                 ]), method: "DELETE"))
+        }
+
+        /**
+         Revoke a Certificate Signing Request
+         
+         - parameter idpId: (path)  
+         - parameter csrId: (path)  
+         - parameter completion: Completion block
+         */
+        public func revokeCsrForIdentityProvider(idpId: String, csrId: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/idps/{idpId}/credentials/csrs/{csrId}".expanded(using: [
+                        "idpId": idpId, 
+                        "csrId": csrId
+                    ]), method: "DELETE"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -325,6 +722,24 @@ public extension OktaClient {
         }
 
         /**
+         Unlink a User from IdP
+         
+         - parameter idpId: (path)  
+         - parameter userId: (path)  
+         - parameter completion: Completion block
+         */
+        public func unlinkUserFromIdentityProvider(idpId: String, userId: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/idps/{idpId}/users/{userId}".expanded(using: [
+                        "idpId": idpId, 
+                        "userId": userId
+                    ]), method: "DELETE"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Replace an Identity Provider
          
          - parameter idpId: (path)  
@@ -334,6 +749,23 @@ public extension OktaClient {
             try await send(try requestWithBody(to: "/api/v1/idps/{idpId}".expanded(using: [
                     "idpId": idpId
                 ]), method: "PUT", body: identityProvider))
+        }
+
+        /**
+         Replace an Identity Provider
+         
+         - parameter idpId: (path)  
+         - parameter identityProvider: (body)  
+         - parameter completion: Completion block
+         */
+        public func updateIdentityProvider(idpId: String, identityProvider: IdentityProvider, completion: @escaping (Result<OktaResponse<IdentityProvider>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/idps/{idpId}".expanded(using: [
+                        "idpId": idpId
+                    ]), method: "PUT", body: identityProvider), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
     }

--- a/Sources/OktaSdk/ManagementAPI/OktaSdk/InlineHookAPI.swift
+++ b/Sources/OktaSdk/ManagementAPI/OktaSdk/InlineHookAPI.swift
@@ -37,12 +37,42 @@ public extension OktaClient {
         }
 
         /**
+         Activate an Inline Hook
+         
+         - parameter inlineHookId: (path)  
+         - parameter completion: Completion block
+         */
+        public func activateInlineHook(inlineHookId: String, completion: @escaping (Result<OktaResponse<InlineHook>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/inlineHooks/{inlineHookId}/lifecycle/activate".expanded(using: [
+                        "inlineHookId": inlineHookId
+                    ]), method: "POST"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Create an Inline Hook
          
          - parameter inlineHook: (body)  
          */
         public func createInlineHook(inlineHook: InlineHook) async throws -> OktaResponse<InlineHook> {
             try await send(try requestWithBody(to: "/api/v1/inlineHooks", method: "POST", body: inlineHook))
+        }
+
+        /**
+         Create an Inline Hook
+         
+         - parameter inlineHook: (body)  
+         - parameter completion: Completion block
+         */
+        public func createInlineHook(inlineHook: InlineHook, completion: @escaping (Result<OktaResponse<InlineHook>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/inlineHooks", method: "POST", body: inlineHook), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -54,6 +84,22 @@ public extension OktaClient {
             try await send(try request(to: "/api/v1/inlineHooks/{inlineHookId}/lifecycle/deactivate".expanded(using: [
                     "inlineHookId": inlineHookId
                 ]), method: "POST"))
+        }
+
+        /**
+         Deactivate an Inline Hook
+         
+         - parameter inlineHookId: (path)  
+         - parameter completion: Completion block
+         */
+        public func deactivateInlineHook(inlineHookId: String, completion: @escaping (Result<OktaResponse<InlineHook>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/inlineHooks/{inlineHookId}/lifecycle/deactivate".expanded(using: [
+                        "inlineHookId": inlineHookId
+                    ]), method: "POST"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -69,6 +115,22 @@ public extension OktaClient {
         }
 
         /**
+         Delete an Inline Hook
+         
+         - parameter inlineHookId: (path)  
+         - parameter completion: Completion block
+         */
+        public func deleteInlineHook(inlineHookId: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/inlineHooks/{inlineHookId}".expanded(using: [
+                        "inlineHookId": inlineHookId
+                    ]), method: "DELETE"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Execute an Inline Hook
          
          - parameter inlineHookId: (path)  
@@ -78,6 +140,23 @@ public extension OktaClient {
             try await send(try requestWithBody(to: "/api/v1/inlineHooks/{inlineHookId}/execute".expanded(using: [
                     "inlineHookId": inlineHookId
                 ]), method: "POST", body: payloadData))
+        }
+
+        /**
+         Execute an Inline Hook
+         
+         - parameter inlineHookId: (path)  
+         - parameter payloadData: (body)  
+         - parameter completion: Completion block
+         */
+        public func executeInlineHook(inlineHookId: String, payloadData: AnyCodable, completion: @escaping (Result<OktaResponse<InlineHookResponse>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/inlineHooks/{inlineHookId}/execute".expanded(using: [
+                        "inlineHookId": inlineHookId
+                    ]), method: "POST", body: payloadData), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -92,6 +171,22 @@ public extension OktaClient {
         }
 
         /**
+         Retrieve an Inline Hook
+         
+         - parameter inlineHookId: (path)  
+         - parameter completion: Completion block
+         */
+        public func getInlineHook(inlineHookId: String, completion: @escaping (Result<OktaResponse<InlineHook>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/inlineHooks/{inlineHookId}".expanded(using: [
+                        "inlineHookId": inlineHookId
+                    ]), method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          List all Inline Hooks
          
          - parameter type: (query)  (optional)
@@ -100,6 +195,22 @@ public extension OktaClient {
             try await send(try request(to: "/api/v1/inlineHooks", method: "GET", query: [
                     "type": type
                 ]))
+        }
+
+        /**
+         List all Inline Hooks
+         
+         - parameter type: (query)  (optional)
+         - parameter completion: Completion block
+         */
+        public func listInlineHooks(type: String? = nil, completion: @escaping (Result<OktaResponse<[InlineHook]>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/inlineHooks", method: "GET", query: [
+                        "type": type
+                    ]), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -112,6 +223,23 @@ public extension OktaClient {
             try await send(try requestWithBody(to: "/api/v1/inlineHooks/{inlineHookId}".expanded(using: [
                     "inlineHookId": inlineHookId
                 ]), method: "PUT", body: inlineHook))
+        }
+
+        /**
+         Replace an Inline Hook
+         
+         - parameter inlineHookId: (path)  
+         - parameter inlineHook: (body)  
+         - parameter completion: Completion block
+         */
+        public func updateInlineHook(inlineHookId: String, inlineHook: InlineHook, completion: @escaping (Result<OktaResponse<InlineHook>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/inlineHooks/{inlineHookId}".expanded(using: [
+                        "inlineHookId": inlineHookId
+                    ]), method: "PUT", body: inlineHook), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
     }

--- a/Sources/OktaSdk/ManagementAPI/OktaSdk/LinkedObjectAPI.swift
+++ b/Sources/OktaSdk/ManagementAPI/OktaSdk/LinkedObjectAPI.swift
@@ -35,6 +35,20 @@ public extension OktaClient {
         }
 
         /**
+         Create a Linked Object Definition
+         
+         - parameter linkedObject: (body)  
+         - parameter completion: Completion block
+         */
+        public func addLinkedObjectDefinition(linkedObject: LinkedObject, completion: @escaping (Result<OktaResponse<LinkedObject>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/meta/schemas/user/linkedObjects", method: "POST", body: linkedObject), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Delete a Linked Object Definition
          
          - parameter linkedObjectName: (path)  
@@ -44,6 +58,22 @@ public extension OktaClient {
             try await send(try request(to: "/api/v1/meta/schemas/user/linkedObjects/{linkedObjectName}".expanded(using: [
                     "linkedObjectName": linkedObjectName
                 ]), method: "DELETE"))
+        }
+
+        /**
+         Delete a Linked Object Definition
+         
+         - parameter linkedObjectName: (path)  
+         - parameter completion: Completion block
+         */
+        public func deleteLinkedObjectDefinition(linkedObjectName: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/meta/schemas/user/linkedObjects/{linkedObjectName}".expanded(using: [
+                        "linkedObjectName": linkedObjectName
+                    ]), method: "DELETE"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -58,11 +88,40 @@ public extension OktaClient {
         }
 
         /**
+         Retrieve a Linked Object Definition
+         
+         - parameter linkedObjectName: (path)  
+         - parameter completion: Completion block
+         */
+        public func getLinkedObjectDefinition(linkedObjectName: String, completion: @escaping (Result<OktaResponse<LinkedObject>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/meta/schemas/user/linkedObjects/{linkedObjectName}".expanded(using: [
+                        "linkedObjectName": linkedObjectName
+                    ]), method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          List all Linked Object Definitions
          
          */
         public func listLinkedObjectDefinitions() async throws -> OktaResponse<[LinkedObject]> {
             try await send(try request(to: "/api/v1/meta/schemas/user/linkedObjects", method: "GET"))
+        }
+
+        /**
+         List all Linked Object Definitions
+         
+         - parameter completion: Completion block
+         */
+        public func listLinkedObjectDefinitions(completion: @escaping (Result<OktaResponse<[LinkedObject]>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/meta/schemas/user/linkedObjects", method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
     }

--- a/Sources/OktaSdk/ManagementAPI/OktaSdk/NetworkZoneAPI.swift
+++ b/Sources/OktaSdk/ManagementAPI/OktaSdk/NetworkZoneAPI.swift
@@ -37,12 +37,42 @@ public extension OktaClient {
         }
 
         /**
+         Activate a Network Zone
+         
+         - parameter zoneId: (path)  
+         - parameter completion: Completion block
+         */
+        public func activateNetworkZone(zoneId: String, completion: @escaping (Result<OktaResponse<NetworkZone>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/zones/{zoneId}/lifecycle/activate".expanded(using: [
+                        "zoneId": zoneId
+                    ]), method: "POST"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Create a Network Zone
          
          - parameter zone: (body)  
          */
         public func createNetworkZone(zone: NetworkZone) async throws -> OktaResponse<NetworkZone> {
             try await send(try requestWithBody(to: "/api/v1/zones", method: "POST", body: zone))
+        }
+
+        /**
+         Create a Network Zone
+         
+         - parameter zone: (body)  
+         - parameter completion: Completion block
+         */
+        public func createNetworkZone(zone: NetworkZone, completion: @escaping (Result<OktaResponse<NetworkZone>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/zones", method: "POST", body: zone), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -54,6 +84,22 @@ public extension OktaClient {
             try await send(try request(to: "/api/v1/zones/{zoneId}/lifecycle/deactivate".expanded(using: [
                     "zoneId": zoneId
                 ]), method: "POST"))
+        }
+
+        /**
+         Deactivate a Network Zone
+         
+         - parameter zoneId: (path)  
+         - parameter completion: Completion block
+         */
+        public func deactivateNetworkZone(zoneId: String, completion: @escaping (Result<OktaResponse<NetworkZone>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/zones/{zoneId}/lifecycle/deactivate".expanded(using: [
+                        "zoneId": zoneId
+                    ]), method: "POST"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -69,6 +115,22 @@ public extension OktaClient {
         }
 
         /**
+         Delete a Network Zone
+         
+         - parameter zoneId: (path)  
+         - parameter completion: Completion block
+         */
+        public func deleteNetworkZone(zoneId: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/zones/{zoneId}".expanded(using: [
+                        "zoneId": zoneId
+                    ]), method: "DELETE"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Retrieve a Network Zone
          
          - parameter zoneId: (path)  
@@ -77,6 +139,22 @@ public extension OktaClient {
             try await send(try request(to: "/api/v1/zones/{zoneId}".expanded(using: [
                     "zoneId": zoneId
                 ]), method: "GET"))
+        }
+
+        /**
+         Retrieve a Network Zone
+         
+         - parameter zoneId: (path)  
+         - parameter completion: Completion block
+         */
+        public func getNetworkZone(zoneId: String, completion: @escaping (Result<OktaResponse<NetworkZone>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/zones/{zoneId}".expanded(using: [
+                        "zoneId": zoneId
+                    ]), method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -95,6 +173,26 @@ public extension OktaClient {
         }
 
         /**
+         List all Network Zones
+         
+         - parameter after: (query) Specifies the pagination cursor for the next page of network zones (optional)
+         - parameter limit: (query) Specifies the number of results for a page (optional, default to -1)
+         - parameter filter: (query) Filters zones by usage or id expression (optional)
+         - parameter completion: Completion block
+         */
+        public func listNetworkZones(after: String? = nil, limit: Int? = nil, filter: String? = nil, completion: @escaping (Result<OktaResponse<[NetworkZone]>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/zones", method: "GET", query: [
+                        "after": after, 
+                        "limit": limit, 
+                        "filter": filter
+                    ]), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Replace a Network Zone
          
          - parameter zoneId: (path)  
@@ -104,6 +202,23 @@ public extension OktaClient {
             try await send(try requestWithBody(to: "/api/v1/zones/{zoneId}".expanded(using: [
                     "zoneId": zoneId
                 ]), method: "PUT", body: zone))
+        }
+
+        /**
+         Replace a Network Zone
+         
+         - parameter zoneId: (path)  
+         - parameter zone: (body)  
+         - parameter completion: Completion block
+         */
+        public func updateNetworkZone(zoneId: String, zone: NetworkZone, completion: @escaping (Result<OktaResponse<NetworkZone>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/zones/{zoneId}".expanded(using: [
+                        "zoneId": zoneId
+                    ]), method: "PUT", body: zone), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
     }

--- a/Sources/OktaSdk/ManagementAPI/OktaSdk/OrgSettingAPI.swift
+++ b/Sources/OktaSdk/ManagementAPI/OktaSdk/OrgSettingAPI.swift
@@ -35,11 +35,38 @@ public extension OktaClient {
         }
 
         /**
+         Remove Emails from Email Provider Bounce List
+         
+         - parameter bouncesRemoveListObj: (body)  (optional)
+         - parameter completion: Completion block
+         */
+        public func bulkRemoveEmailAddressBounces(bouncesRemoveListObj: BouncesRemoveListObj? = nil, completion: @escaping (Result<OktaResponse<BouncesRemoveListResult>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/org/email/bounces/remove-list", method: "POST", body: bouncesRemoveListObj), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Extend Okta Support Access
          
          */
         public func extendOktaSupport() async throws -> OktaResponse<OrgOktaSupportSettingsObj> {
             try await send(try request(to: "/api/v1/org/privacy/oktaSupport/extend", method: "POST"))
+        }
+
+        /**
+         Extend Okta Support Access
+         
+         - parameter completion: Completion block
+         */
+        public func extendOktaSupport(completion: @escaping (Result<OktaResponse<OrgOktaSupportSettingsObj>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/org/privacy/oktaSupport/extend", method: "POST"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -51,11 +78,37 @@ public extension OktaClient {
         }
 
         /**
+         Retreive the Okta Communication Settings
+         
+         - parameter completion: Completion block
+         */
+        public func getOktaCommunicationSettings(completion: @escaping (Result<OktaResponse<OrgOktaCommunicationSetting>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/org/privacy/oktaCommunication", method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Retrieve the Org Contact Types
          
          */
         public func getOrgContactTypes() async throws -> OktaResponse<[OrgContactTypeObj]> {
             try await send(try request(to: "/api/v1/org/contacts", method: "GET"))
+        }
+
+        /**
+         Retrieve the Org Contact Types
+         
+         - parameter completion: Completion block
+         */
+        public func getOrgContactTypes(completion: @escaping (Result<OktaResponse<[OrgContactTypeObj]>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/org/contacts", method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -70,11 +123,40 @@ public extension OktaClient {
         }
 
         /**
+         Retrieve the User of the Contact Type
+         
+         - parameter contactType: (path)  
+         - parameter completion: Completion block
+         */
+        public func getOrgContactUser(contactType: String, completion: @escaping (Result<OktaResponse<OrgContactUser>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/org/contacts/{contactType}".expanded(using: [
+                        "contactType": contactType
+                    ]), method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Retrieve the Okta Support Settings
          
          */
         public func getOrgOktaSupportSettings() async throws -> OktaResponse<OrgOktaSupportSettingsObj> {
             try await send(try request(to: "/api/v1/org/privacy/oktaSupport", method: "GET"))
+        }
+
+        /**
+         Retrieve the Okta Support Settings
+         
+         - parameter completion: Completion block
+         */
+        public func getOrgOktaSupportSettings(completion: @escaping (Result<OktaResponse<OrgOktaSupportSettingsObj>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/org/privacy/oktaSupport", method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -86,11 +168,37 @@ public extension OktaClient {
         }
 
         /**
+         Retrieve the Org Preferences
+         
+         - parameter completion: Completion block
+         */
+        public func getOrgPreferences(completion: @escaping (Result<OktaResponse<OrgPreferences>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/org/preferences", method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Retrieve the Org Settings
          
          */
         public func getOrgSettings() async throws -> OktaResponse<OrgSetting> {
             try await send(try request(to: "/api/v1/org", method: "GET"))
+        }
+
+        /**
+         Retrieve the Org Settings
+         
+         - parameter completion: Completion block
+         */
+        public func getOrgSettings(completion: @escaping (Result<OktaResponse<OrgSetting>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/org", method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -102,11 +210,37 @@ public extension OktaClient {
         }
 
         /**
+         Grant Okta Support Access to your Org
+         
+         - parameter completion: Completion block
+         */
+        public func grantOktaSupport(completion: @escaping (Result<OktaResponse<OrgOktaSupportSettingsObj>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/org/privacy/oktaSupport/grant", method: "POST"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Update the Preference to Hide the Okta Dashboard Footer
          
          */
         public func hideOktaUIFooter() async throws -> OktaResponse<OrgPreferences> {
             try await send(try request(to: "/api/v1/org/preferences/hideEndUserFooter", method: "POST"))
+        }
+
+        /**
+         Update the Preference to Hide the Okta Dashboard Footer
+         
+         - parameter completion: Completion block
+         */
+        public func hideOktaUIFooter(completion: @escaping (Result<OktaResponse<OrgPreferences>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/org/preferences/hideEndUserFooter", method: "POST"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -118,11 +252,37 @@ public extension OktaClient {
         }
 
         /**
+         Opt in all Users to Okta Communication emails
+         
+         - parameter completion: Completion block
+         */
+        public func optInUsersToOktaCommunicationEmails(completion: @escaping (Result<OktaResponse<OrgOktaCommunicationSetting>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/org/privacy/oktaCommunication/optIn", method: "POST"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Opt out all Users from Okta Communication emails
          
          */
         public func optOutUsersFromOktaCommunicationEmails() async throws -> OktaResponse<OrgOktaCommunicationSetting> {
             try await send(try request(to: "/api/v1/org/privacy/oktaCommunication/optOut", method: "POST"))
+        }
+
+        /**
+         Opt out all Users from Okta Communication emails
+         
+         - parameter completion: Completion block
+         */
+        public func optOutUsersFromOktaCommunicationEmails(completion: @escaping (Result<OktaResponse<OrgOktaCommunicationSetting>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/org/privacy/oktaCommunication/optOut", method: "POST"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -135,6 +295,20 @@ public extension OktaClient {
         }
 
         /**
+         Update the Org Settings
+         
+         - parameter orgSetting: (body)  (optional)
+         - parameter completion: Completion block
+         */
+        public func partialUpdateOrgSetting(orgSetting: OrgSetting? = nil, completion: @escaping (Result<OktaResponse<OrgSetting>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/org", method: "POST", body: orgSetting), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Revoke Okta Support Access
          
          */
@@ -143,11 +317,37 @@ public extension OktaClient {
         }
 
         /**
+         Revoke Okta Support Access
+         
+         - parameter completion: Completion block
+         */
+        public func revokeOktaSupport(completion: @escaping (Result<OktaResponse<OrgOktaSupportSettingsObj>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/org/privacy/oktaSupport/revoke", method: "POST"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Update the Preference to Show the Okta Dashboard Footer
          
          */
         public func showOktaUIFooter() async throws -> OktaResponse<OrgPreferences> {
             try await send(try request(to: "/api/v1/org/preferences/showEndUserFooter", method: "POST"))
+        }
+
+        /**
+         Update the Preference to Show the Okta Dashboard Footer
+         
+         - parameter completion: Completion block
+         */
+        public func showOktaUIFooter(completion: @escaping (Result<OktaResponse<OrgPreferences>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/org/preferences/showEndUserFooter", method: "POST"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -163,6 +363,23 @@ public extension OktaClient {
         }
 
         /**
+         Replace the User of the Contact Type
+         
+         - parameter contactType: (path)  
+         - parameter orgContactUser: (body)  
+         - parameter completion: Completion block
+         */
+        public func updateOrgContactUser(contactType: String, orgContactUser: OrgContactUser, completion: @escaping (Result<OktaResponse<OrgContactUser>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/org/contacts/{contactType}".expanded(using: [
+                        "contactType": contactType
+                    ]), method: "PUT", body: orgContactUser), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Upload the Org Logo
          
          - parameter file: (form)  
@@ -173,12 +390,40 @@ public extension OktaClient {
         }
 
         /**
+         Upload the Org Logo
+         
+         - parameter file: (form)  
+         - parameter completion: Completion block
+         */
+        public func updateOrgLogo(file: URL, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/org/logo", method: "POST"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Replace the Org Settings
          
          - parameter orgSetting: (body)  
          */
         public func updateOrgSetting(orgSetting: OrgSetting) async throws -> OktaResponse<OrgSetting> {
             try await send(try requestWithBody(to: "/api/v1/org", method: "PUT", body: orgSetting))
+        }
+
+        /**
+         Replace the Org Settings
+         
+         - parameter orgSetting: (body)  
+         - parameter completion: Completion block
+         */
+        public func updateOrgSetting(orgSetting: OrgSetting, completion: @escaping (Result<OktaResponse<OrgSetting>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/org", method: "PUT", body: orgSetting), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
     }

--- a/Sources/OktaSdk/ManagementAPI/OktaSdk/PolicyAPI.swift
+++ b/Sources/OktaSdk/ManagementAPI/OktaSdk/PolicyAPI.swift
@@ -38,6 +38,22 @@ public extension OktaClient {
         }
 
         /**
+         Activate a Policy
+         
+         - parameter policyId: (path)  
+         - parameter completion: Completion block
+         */
+        public func activatePolicy(policyId: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/policies/{policyId}/lifecycle/activate".expanded(using: [
+                        "policyId": policyId
+                    ]), method: "POST"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Activate a Policy Rule
          
          - parameter policyId: (path)  
@@ -49,6 +65,24 @@ public extension OktaClient {
                     "policyId": policyId, 
                     "ruleId": ruleId
                 ]), method: "POST"))
+        }
+
+        /**
+         Activate a Policy Rule
+         
+         - parameter policyId: (path)  
+         - parameter ruleId: (path)  
+         - parameter completion: Completion block
+         */
+        public func activatePolicyRule(policyId: String, ruleId: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/policies/{policyId}/rules/{ruleId}/lifecycle/activate".expanded(using: [
+                        "policyId": policyId, 
+                        "ruleId": ruleId
+                    ]), method: "POST"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -64,6 +98,23 @@ public extension OktaClient {
         }
 
         /**
+         Create a Policy
+         
+         - parameter policy: (body)  
+         - parameter activate: (query)  (optional, default to true)
+         - parameter completion: Completion block
+         */
+        public func createPolicy(policy: Policy, activate: Bool? = nil, completion: @escaping (Result<OktaResponse<Policy>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/policies", method: "POST", query: [
+                        "activate": activate
+                    ], body: policy), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Create a Policy Rule
          
          - parameter policyId: (path)  
@@ -76,6 +127,23 @@ public extension OktaClient {
         }
 
         /**
+         Create a Policy Rule
+         
+         - parameter policyId: (path)  
+         - parameter policyRule: (body)  
+         - parameter completion: Completion block
+         */
+        public func createPolicyRule(policyId: String, policyRule: PolicyRule, completion: @escaping (Result<OktaResponse<PolicyRule>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/policies/{policyId}/rules".expanded(using: [
+                        "policyId": policyId
+                    ]), method: "POST", body: policyRule), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Deactivate a Policy
          
          - parameter policyId: (path)  
@@ -85,6 +153,22 @@ public extension OktaClient {
             try await send(try request(to: "/api/v1/policies/{policyId}/lifecycle/deactivate".expanded(using: [
                     "policyId": policyId
                 ]), method: "POST"))
+        }
+
+        /**
+         Deactivate a Policy
+         
+         - parameter policyId: (path)  
+         - parameter completion: Completion block
+         */
+        public func deactivatePolicy(policyId: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/policies/{policyId}/lifecycle/deactivate".expanded(using: [
+                        "policyId": policyId
+                    ]), method: "POST"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -102,6 +186,24 @@ public extension OktaClient {
         }
 
         /**
+         Deactivate a Policy Rule
+         
+         - parameter policyId: (path)  
+         - parameter ruleId: (path)  
+         - parameter completion: Completion block
+         */
+        public func deactivatePolicyRule(policyId: String, ruleId: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/policies/{policyId}/rules/{ruleId}/lifecycle/deactivate".expanded(using: [
+                        "policyId": policyId, 
+                        "ruleId": ruleId
+                    ]), method: "POST"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Delete a Policy
          
          - parameter policyId: (path)  
@@ -111,6 +213,22 @@ public extension OktaClient {
             try await send(try request(to: "/api/v1/policies/{policyId}".expanded(using: [
                     "policyId": policyId
                 ]), method: "DELETE"))
+        }
+
+        /**
+         Delete a Policy
+         
+         - parameter policyId: (path)  
+         - parameter completion: Completion block
+         */
+        public func deletePolicy(policyId: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/policies/{policyId}".expanded(using: [
+                        "policyId": policyId
+                    ]), method: "DELETE"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -128,6 +246,24 @@ public extension OktaClient {
         }
 
         /**
+         Delete a Policy Rule
+         
+         - parameter policyId: (path)  
+         - parameter ruleId: (path)  
+         - parameter completion: Completion block
+         */
+        public func deletePolicyRule(policyId: String, ruleId: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/policies/{policyId}/rules/{ruleId}".expanded(using: [
+                        "policyId": policyId, 
+                        "ruleId": ruleId
+                    ]), method: "DELETE"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Retrieve a Policy
          
          - parameter policyId: (path)  
@@ -142,6 +278,25 @@ public extension OktaClient {
         }
 
         /**
+         Retrieve a Policy
+         
+         - parameter policyId: (path)  
+         - parameter expand: (query)  (optional, default to "")
+         - parameter completion: Completion block
+         */
+        public func getPolicy(policyId: String, expand: String? = nil, completion: @escaping (Result<OktaResponse<Policy>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/policies/{policyId}".expanded(using: [
+                        "policyId": policyId
+                    ]), method: "GET", query: [
+                        "expand": expand
+                    ]), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Retrieve a Policy Rule
          
          - parameter policyId: (path)  
@@ -152,6 +307,24 @@ public extension OktaClient {
                     "policyId": policyId, 
                     "ruleId": ruleId
                 ]), method: "GET"))
+        }
+
+        /**
+         Retrieve a Policy Rule
+         
+         - parameter policyId: (path)  
+         - parameter ruleId: (path)  
+         - parameter completion: Completion block
+         */
+        public func getPolicyRule(policyId: String, ruleId: String, completion: @escaping (Result<OktaResponse<PolicyRule>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/policies/{policyId}/rules/{ruleId}".expanded(using: [
+                        "policyId": policyId, 
+                        "ruleId": ruleId
+                    ]), method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -170,6 +343,26 @@ public extension OktaClient {
         }
 
         /**
+         List all Policies
+         
+         - parameter type: (query)  
+         - parameter status: (query)  (optional)
+         - parameter expand: (query)  (optional, default to "")
+         - parameter completion: Completion block
+         */
+        public func listPolicies(type: String, status: String? = nil, expand: String? = nil, completion: @escaping (Result<OktaResponse<[Policy]>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/policies", method: "GET", query: [
+                        "type": type, 
+                        "status": status, 
+                        "expand": expand
+                    ]), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          List all Policy Rules
          
          - parameter policyId: (path)  
@@ -178,6 +371,22 @@ public extension OktaClient {
             try await send(try request(to: "/api/v1/policies/{policyId}/rules".expanded(using: [
                     "policyId": policyId
                 ]), method: "GET"))
+        }
+
+        /**
+         List all Policy Rules
+         
+         - parameter policyId: (path)  
+         - parameter completion: Completion block
+         */
+        public func listPolicyRules(policyId: String, completion: @escaping (Result<OktaResponse<[PolicyRule]>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/policies/{policyId}/rules".expanded(using: [
+                        "policyId": policyId
+                    ]), method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -193,6 +402,23 @@ public extension OktaClient {
         }
 
         /**
+         Replace a Policy
+         
+         - parameter policyId: (path)  
+         - parameter policy: (body)  
+         - parameter completion: Completion block
+         */
+        public func updatePolicy(policyId: String, policy: Policy, completion: @escaping (Result<OktaResponse<Policy>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/policies/{policyId}".expanded(using: [
+                        "policyId": policyId
+                    ]), method: "PUT", body: policy), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Replace a Policy Rule
          
          - parameter policyId: (path)  
@@ -204,6 +430,25 @@ public extension OktaClient {
                     "policyId": policyId, 
                     "ruleId": ruleId
                 ]), method: "PUT", body: policyRule))
+        }
+
+        /**
+         Replace a Policy Rule
+         
+         - parameter policyId: (path)  
+         - parameter ruleId: (path)  
+         - parameter policyRule: (body)  
+         - parameter completion: Completion block
+         */
+        public func updatePolicyRule(policyId: String, ruleId: String, policyRule: PolicyRule, completion: @escaping (Result<OktaResponse<PolicyRule>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/policies/{policyId}/rules/{ruleId}".expanded(using: [
+                        "policyId": policyId, 
+                        "ruleId": ruleId
+                    ]), method: "PUT", body: policyRule), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
     }

--- a/Sources/OktaSdk/ManagementAPI/OktaSdk/PrincipalRateLimitAPI.swift
+++ b/Sources/OktaSdk/ManagementAPI/OktaSdk/PrincipalRateLimitAPI.swift
@@ -35,6 +35,20 @@ public extension OktaClient {
         }
 
         /**
+         Create a Principal Rate Limit
+         
+         - parameter entity: (body)  
+         - parameter completion: Completion block
+         */
+        public func createPrincipalRateLimitEntity(entity: PrincipalRateLimitEntity, completion: @escaping (Result<OktaResponse<PrincipalRateLimitEntity>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/principal-rate-limits", method: "POST", body: entity), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Retrieve a Principal Rate Limit
          
          - parameter principalRateLimitId: (path) id of the Principal Rate Limit 
@@ -43,6 +57,22 @@ public extension OktaClient {
             try await send(try request(to: "/api/v1/principal-rate-limits/{principalRateLimitId}".expanded(using: [
                     "principalRateLimitId": principalRateLimitId
                 ]), method: "GET"))
+        }
+
+        /**
+         Retrieve a Principal Rate Limit
+         
+         - parameter principalRateLimitId: (path) id of the Principal Rate Limit 
+         - parameter completion: Completion block
+         */
+        public func getPrincipalRateLimitEntity(principalRateLimitId: String, completion: @escaping (Result<OktaResponse<PrincipalRateLimitEntity>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/principal-rate-limits/{principalRateLimitId}".expanded(using: [
+                        "principalRateLimitId": principalRateLimitId
+                    ]), method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -61,6 +91,26 @@ public extension OktaClient {
         }
 
         /**
+         List all Principal Rate Limits
+         
+         - parameter filter: (query)  (optional)
+         - parameter after: (query)  (optional)
+         - parameter limit: (query)  (optional, default to 20)
+         - parameter completion: Completion block
+         */
+        public func listPrincipalRateLimitEntities(filter: String? = nil, after: String? = nil, limit: Int? = nil, completion: @escaping (Result<OktaResponse<[PrincipalRateLimitEntity]>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/principal-rate-limits", method: "GET", query: [
+                        "filter": filter, 
+                        "after": after, 
+                        "limit": limit
+                    ]), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Replace a Principal Rate Limit
          
          - parameter principalRateLimitId: (path) id of the Principal Rate Limit 
@@ -70,6 +120,23 @@ public extension OktaClient {
             try await send(try requestWithBody(to: "/api/v1/principal-rate-limits/{principalRateLimitId}".expanded(using: [
                     "principalRateLimitId": principalRateLimitId
                 ]), method: "PUT", body: entity))
+        }
+
+        /**
+         Replace a Principal Rate Limit
+         
+         - parameter principalRateLimitId: (path) id of the Principal Rate Limit 
+         - parameter entity: (body)  
+         - parameter completion: Completion block
+         */
+        public func updatePrincipalRateLimitEntity(principalRateLimitId: String, entity: PrincipalRateLimitEntity, completion: @escaping (Result<OktaResponse<PrincipalRateLimitEntity>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/principal-rate-limits/{principalRateLimitId}".expanded(using: [
+                        "principalRateLimitId": principalRateLimitId
+                    ]), method: "PUT", body: entity), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
     }

--- a/Sources/OktaSdk/ManagementAPI/OktaSdk/ProfileMappingAPI.swift
+++ b/Sources/OktaSdk/ManagementAPI/OktaSdk/ProfileMappingAPI.swift
@@ -37,6 +37,22 @@ public extension OktaClient {
         }
 
         /**
+         Retrieve a Profile Mapping
+         
+         - parameter mappingId: (path)  
+         - parameter completion: Completion block
+         */
+        public func getProfileMapping(mappingId: String, completion: @escaping (Result<OktaResponse<ProfileMapping>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/mappings/{mappingId}".expanded(using: [
+                        "mappingId": mappingId
+                    ]), method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          List all Profile Mappings
          
          - parameter after: (query)  (optional)
@@ -54,6 +70,28 @@ public extension OktaClient {
         }
 
         /**
+         List all Profile Mappings
+         
+         - parameter after: (query)  (optional)
+         - parameter limit: (query)  (optional, default to -1)
+         - parameter sourceId: (query)  (optional)
+         - parameter targetId: (query)  (optional, default to "")
+         - parameter completion: Completion block
+         */
+        public func listProfileMappings(after: String? = nil, limit: Int? = nil, sourceId: String? = nil, targetId: String? = nil, completion: @escaping (Result<OktaResponse<[ProfileMapping]>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/mappings", method: "GET", query: [
+                        "after": after, 
+                        "limit": limit, 
+                        "sourceId": sourceId, 
+                        "targetId": targetId
+                    ]), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Update a Profile Mapping
          
          - parameter mappingId: (path)  
@@ -63,6 +101,23 @@ public extension OktaClient {
             try await send(try requestWithBody(to: "/api/v1/mappings/{mappingId}".expanded(using: [
                     "mappingId": mappingId
                 ]), method: "POST", body: profileMapping))
+        }
+
+        /**
+         Update a Profile Mapping
+         
+         - parameter mappingId: (path)  
+         - parameter profileMapping: (body)  
+         - parameter completion: Completion block
+         */
+        public func updateProfileMapping(mappingId: String, profileMapping: ProfileMapping, completion: @escaping (Result<OktaResponse<ProfileMapping>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/mappings/{mappingId}".expanded(using: [
+                        "mappingId": mappingId
+                    ]), method: "POST", body: profileMapping), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
     }

--- a/Sources/OktaSdk/ManagementAPI/OktaSdk/SchemaAPI.swift
+++ b/Sources/OktaSdk/ManagementAPI/OktaSdk/SchemaAPI.swift
@@ -37,11 +37,40 @@ public extension OktaClient {
         }
 
         /**
+         Retrieve the default Application User Schema for an Application
+         
+         - parameter appInstanceId: (path)  
+         - parameter completion: Completion block
+         */
+        public func getApplicationUserSchema(appInstanceId: String, completion: @escaping (Result<OktaResponse<UserSchema>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/meta/schemas/apps/{appInstanceId}/default".expanded(using: [
+                        "appInstanceId": appInstanceId
+                    ]), method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Retrieve the default Group Schema
          
          */
         public func getGroupSchema() async throws -> OktaResponse<GroupSchema> {
             try await send(try request(to: "/api/v1/meta/schemas/group/default", method: "GET"))
+        }
+
+        /**
+         Retrieve the default Group Schema
+         
+         - parameter completion: Completion block
+         */
+        public func getGroupSchema(completion: @escaping (Result<OktaResponse<GroupSchema>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/meta/schemas/group/default", method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -53,6 +82,22 @@ public extension OktaClient {
             try await send(try request(to: "/api/v1/meta/schemas/user/{schemaId}".expanded(using: [
                     "schemaId": schemaId
                 ]), method: "GET"))
+        }
+
+        /**
+         Retrieve a User Schema
+         
+         - parameter schemaId: (path)  
+         - parameter completion: Completion block
+         */
+        public func getUserSchema(schemaId: String, completion: @escaping (Result<OktaResponse<UserSchema>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/meta/schemas/user/{schemaId}".expanded(using: [
+                        "schemaId": schemaId
+                    ]), method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -68,12 +113,43 @@ public extension OktaClient {
         }
 
         /**
+         Update the default Application User Schema for an Application
+         
+         - parameter appInstanceId: (path)  
+         - parameter body: (body)  (optional)
+         - parameter completion: Completion block
+         */
+        public func updateApplicationUserProfile(appInstanceId: String, body: UserSchema? = nil, completion: @escaping (Result<OktaResponse<UserSchema>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/meta/schemas/apps/{appInstanceId}/default".expanded(using: [
+                        "appInstanceId": appInstanceId
+                    ]), method: "POST", body: body), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Update the default Group Schema
          
          - parameter groupSchema: (body)  (optional)
          */
         public func updateGroupSchema(groupSchema: GroupSchema? = nil) async throws -> OktaResponse<GroupSchema> {
             try await send(try requestWithBody(to: "/api/v1/meta/schemas/group/default", method: "POST", body: groupSchema))
+        }
+
+        /**
+         Update the default Group Schema
+         
+         - parameter groupSchema: (body)  (optional)
+         - parameter completion: Completion block
+         */
+        public func updateGroupSchema(groupSchema: GroupSchema? = nil, completion: @escaping (Result<OktaResponse<GroupSchema>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/meta/schemas/group/default", method: "POST", body: groupSchema), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -86,6 +162,23 @@ public extension OktaClient {
             try await send(try requestWithBody(to: "/api/v1/meta/schemas/user/{schemaId}".expanded(using: [
                     "schemaId": schemaId
                 ]), method: "POST", body: userSchema))
+        }
+
+        /**
+         Update a User Schema
+         
+         - parameter schemaId: (path)  
+         - parameter userSchema: (body)  
+         - parameter completion: Completion block
+         */
+        public func updateUserProfile(schemaId: String, userSchema: UserSchema, completion: @escaping (Result<OktaResponse<UserSchema>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/meta/schemas/user/{schemaId}".expanded(using: [
+                        "schemaId": schemaId
+                    ]), method: "POST", body: userSchema), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
     }

--- a/Sources/OktaSdk/ManagementAPI/OktaSdk/SessionAPI.swift
+++ b/Sources/OktaSdk/ManagementAPI/OktaSdk/SessionAPI.swift
@@ -35,6 +35,20 @@ public extension OktaClient {
         }
 
         /**
+         Create a Session with Session Token
+         
+         - parameter createSessionRequest: (body)  
+         - parameter completion: Completion block
+         */
+        public func createSession(createSessionRequest: CreateSessionRequest, completion: @escaping (Result<OktaResponse<Session>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/sessions", method: "POST", body: createSessionRequest), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Delete a Session
          
          - parameter sessionId: (path)  
@@ -44,6 +58,22 @@ public extension OktaClient {
             try await send(try request(to: "/api/v1/sessions/{sessionId}".expanded(using: [
                     "sessionId": sessionId
                 ]), method: "DELETE"))
+        }
+
+        /**
+         Delete a Session
+         
+         - parameter sessionId: (path)  
+         - parameter completion: Completion block
+         */
+        public func endSession(sessionId: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/sessions/{sessionId}".expanded(using: [
+                        "sessionId": sessionId
+                    ]), method: "DELETE"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -58,6 +88,22 @@ public extension OktaClient {
         }
 
         /**
+         Retrieve a Session
+         
+         - parameter sessionId: (path)  
+         - parameter completion: Completion block
+         */
+        public func getSession(sessionId: String, completion: @escaping (Result<OktaResponse<Session>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/sessions/{sessionId}".expanded(using: [
+                        "sessionId": sessionId
+                    ]), method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Refresh a Session
          
          - parameter sessionId: (path)  
@@ -66,6 +112,22 @@ public extension OktaClient {
             try await send(try request(to: "/api/v1/sessions/{sessionId}/lifecycle/refresh".expanded(using: [
                     "sessionId": sessionId
                 ]), method: "POST"))
+        }
+
+        /**
+         Refresh a Session
+         
+         - parameter sessionId: (path)  
+         - parameter completion: Completion block
+         */
+        public func refreshSession(sessionId: String, completion: @escaping (Result<OktaResponse<Session>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/sessions/{sessionId}/lifecycle/refresh".expanded(using: [
+                        "sessionId": sessionId
+                    ]), method: "POST"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
     }

--- a/Sources/OktaSdk/ManagementAPI/OktaSdk/SubscriptionAPI.swift
+++ b/Sources/OktaSdk/ManagementAPI/OktaSdk/SubscriptionAPI.swift
@@ -39,6 +39,24 @@ public extension OktaClient {
         }
 
         /**
+         List all Subscriptions of a Custom Role with a specific notification type
+         
+         - parameter roleTypeOrRoleId: (path)  
+         - parameter notificationType: (path)  
+         - parameter completion: Completion block
+         */
+        public func getRoleSubscriptionByNotificationType(roleTypeOrRoleId: String, notificationType: String, completion: @escaping (Result<OktaResponse<Subscription>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/roles/{roleTypeOrRoleId}/subscriptions/{notificationType}".expanded(using: [
+                        "roleTypeOrRoleId": roleTypeOrRoleId, 
+                        "notificationType": notificationType
+                    ]), method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          List all Subscriptions by type
          
          - parameter userId: (path)  
@@ -49,6 +67,24 @@ public extension OktaClient {
                     "userId": userId, 
                     "notificationType": notificationType
                 ]), method: "GET"))
+        }
+
+        /**
+         List all Subscriptions by type
+         
+         - parameter userId: (path)  
+         - parameter notificationType: (path)  
+         - parameter completion: Completion block
+         */
+        public func getUserSubscriptionByNotificationType(userId: String, notificationType: String, completion: @escaping (Result<OktaResponse<Subscription>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/users/{userId}/subscriptions/{notificationType}".expanded(using: [
+                        "userId": userId, 
+                        "notificationType": notificationType
+                    ]), method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -63,6 +99,22 @@ public extension OktaClient {
         }
 
         /**
+         List all Subscriptions of a Custom Role
+         
+         - parameter roleTypeOrRoleId: (path)  
+         - parameter completion: Completion block
+         */
+        public func listRoleSubscriptions(roleTypeOrRoleId: String, completion: @escaping (Result<OktaResponse<[Subscription]>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/roles/{roleTypeOrRoleId}/subscriptions".expanded(using: [
+                        "roleTypeOrRoleId": roleTypeOrRoleId
+                    ]), method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          List all Subscriptions
          
          - parameter userId: (path)  
@@ -71,6 +123,22 @@ public extension OktaClient {
             try await send(try request(to: "/api/v1/users/{userId}/subscriptions".expanded(using: [
                     "userId": userId
                 ]), method: "GET"))
+        }
+
+        /**
+         List all Subscriptions
+         
+         - parameter userId: (path)  
+         - parameter completion: Completion block
+         */
+        public func listUserSubscriptions(userId: String, completion: @escaping (Result<OktaResponse<[Subscription]>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/users/{userId}/subscriptions".expanded(using: [
+                        "userId": userId
+                    ]), method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -88,6 +156,24 @@ public extension OktaClient {
         }
 
         /**
+         Subscribe a Custom Role to a specific notification type
+         
+         - parameter roleTypeOrRoleId: (path)  
+         - parameter notificationType: (path)  
+         - parameter completion: Completion block
+         */
+        public func subscribeRoleSubscriptionByNotificationType(roleTypeOrRoleId: String, notificationType: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/roles/{roleTypeOrRoleId}/subscriptions/{notificationType}/subscribe".expanded(using: [
+                        "roleTypeOrRoleId": roleTypeOrRoleId, 
+                        "notificationType": notificationType
+                    ]), method: "POST"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Subscribe to a specific notification type
          
          - parameter userId: (path)  
@@ -99,6 +185,24 @@ public extension OktaClient {
                     "userId": userId, 
                     "notificationType": notificationType
                 ]), method: "POST"))
+        }
+
+        /**
+         Subscribe to a specific notification type
+         
+         - parameter userId: (path)  
+         - parameter notificationType: (path)  
+         - parameter completion: Completion block
+         */
+        public func subscribeUserSubscriptionByNotificationType(userId: String, notificationType: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/users/{userId}/subscriptions/{notificationType}/subscribe".expanded(using: [
+                        "userId": userId, 
+                        "notificationType": notificationType
+                    ]), method: "POST"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -116,6 +220,24 @@ public extension OktaClient {
         }
 
         /**
+         Unsubscribe a Custom Role from a specific notification type
+         
+         - parameter roleTypeOrRoleId: (path)  
+         - parameter notificationType: (path)  
+         - parameter completion: Completion block
+         */
+        public func unsubscribeRoleSubscriptionByNotificationType(roleTypeOrRoleId: String, notificationType: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/roles/{roleTypeOrRoleId}/subscriptions/{notificationType}/unsubscribe".expanded(using: [
+                        "roleTypeOrRoleId": roleTypeOrRoleId, 
+                        "notificationType": notificationType
+                    ]), method: "POST"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Unsubscribe from a specific notification type
          
          - parameter userId: (path)  
@@ -127,6 +249,24 @@ public extension OktaClient {
                     "userId": userId, 
                     "notificationType": notificationType
                 ]), method: "POST"))
+        }
+
+        /**
+         Unsubscribe from a specific notification type
+         
+         - parameter userId: (path)  
+         - parameter notificationType: (path)  
+         - parameter completion: Completion block
+         */
+        public func unsubscribeUserSubscriptionByNotificationType(userId: String, notificationType: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/users/{userId}/subscriptions/{notificationType}/unsubscribe".expanded(using: [
+                        "userId": userId, 
+                        "notificationType": notificationType
+                    ]), method: "POST"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
     }

--- a/Sources/OktaSdk/ManagementAPI/OktaSdk/SystemLogAPI.swift
+++ b/Sources/OktaSdk/ManagementAPI/OktaSdk/SystemLogAPI.swift
@@ -48,5 +48,33 @@ public extension OktaClient {
                 ]))
         }
 
+        /**
+         List all System Log Events
+         
+         - parameter since: (query)  (optional)
+         - parameter until: (query)  (optional)
+         - parameter filter: (query)  (optional)
+         - parameter q: (query)  (optional)
+         - parameter limit: (query)  (optional, default to 100)
+         - parameter sortOrder: (query)  (optional, default to "ASCENDING")
+         - parameter after: (query)  (optional)
+         - parameter completion: Completion block
+         */
+        public func getLogs(since: Date? = nil, until: Date? = nil, filter: String? = nil, q: String? = nil, limit: Int? = nil, sortOrder: String? = nil, after: String? = nil, completion: @escaping (Result<OktaResponse<[LogEvent]>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/logs", method: "GET", query: [
+                        "since": since, 
+                        "until": until, 
+                        "filter": filter, 
+                        "q": q, 
+                        "limit": limit, 
+                        "sortOrder": sortOrder, 
+                        "after": after
+                    ]), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
     }
 }

--- a/Sources/OktaSdk/ManagementAPI/OktaSdk/TemplateAPI.swift
+++ b/Sources/OktaSdk/ManagementAPI/OktaSdk/TemplateAPI.swift
@@ -35,6 +35,20 @@ public extension OktaClient {
         }
 
         /**
+         Create an SMS Template
+         
+         - parameter smsTemplate: (body)  
+         - parameter completion: Completion block
+         */
+        public func createSmsTemplate(smsTemplate: SmsTemplate, completion: @escaping (Result<OktaResponse<SmsTemplate>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/templates/sms", method: "POST", body: smsTemplate), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Delete an SMS Template
          
          - parameter templateId: (path)  
@@ -44,6 +58,22 @@ public extension OktaClient {
             try await send(try request(to: "/api/v1/templates/sms/{templateId}".expanded(using: [
                     "templateId": templateId
                 ]), method: "DELETE"))
+        }
+
+        /**
+         Delete an SMS Template
+         
+         - parameter templateId: (path)  
+         - parameter completion: Completion block
+         */
+        public func deleteSmsTemplate(templateId: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/templates/sms/{templateId}".expanded(using: [
+                        "templateId": templateId
+                    ]), method: "DELETE"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -58,6 +88,22 @@ public extension OktaClient {
         }
 
         /**
+         Retrieve an SMS Template
+         
+         - parameter templateId: (path)  
+         - parameter completion: Completion block
+         */
+        public func getSmsTemplate(templateId: String, completion: @escaping (Result<OktaResponse<SmsTemplate>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/templates/sms/{templateId}".expanded(using: [
+                        "templateId": templateId
+                    ]), method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          List all SMS Templates
          
          - parameter templateType: (query)  (optional)
@@ -66,6 +112,22 @@ public extension OktaClient {
             try await send(try request(to: "/api/v1/templates/sms", method: "GET", query: [
                     "templateType": templateType
                 ]))
+        }
+
+        /**
+         List all SMS Templates
+         
+         - parameter templateType: (query)  (optional)
+         - parameter completion: Completion block
+         */
+        public func listSmsTemplates(templateType: SmsTemplateType? = nil, completion: @escaping (Result<OktaResponse<[SmsTemplate]>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/templates/sms", method: "GET", query: [
+                        "templateType": templateType
+                    ]), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -81,6 +143,23 @@ public extension OktaClient {
         }
 
         /**
+         Update an SMS Template
+         
+         - parameter templateId: (path)  
+         - parameter smsTemplate: (body)  
+         - parameter completion: Completion block
+         */
+        public func partialUpdateSmsTemplate(templateId: String, smsTemplate: SmsTemplate, completion: @escaping (Result<OktaResponse<SmsTemplate>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/templates/sms/{templateId}".expanded(using: [
+                        "templateId": templateId
+                    ]), method: "POST", body: smsTemplate), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Replace an SMS Template
          
          - parameter templateId: (path)  
@@ -90,6 +169,23 @@ public extension OktaClient {
             try await send(try requestWithBody(to: "/api/v1/templates/sms/{templateId}".expanded(using: [
                     "templateId": templateId
                 ]), method: "PUT", body: smsTemplate))
+        }
+
+        /**
+         Replace an SMS Template
+         
+         - parameter templateId: (path)  
+         - parameter smsTemplate: (body)  
+         - parameter completion: Completion block
+         */
+        public func updateSmsTemplate(templateId: String, smsTemplate: SmsTemplate, completion: @escaping (Result<OktaResponse<SmsTemplate>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/templates/sms/{templateId}".expanded(using: [
+                        "templateId": templateId
+                    ]), method: "PUT", body: smsTemplate), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
     }

--- a/Sources/OktaSdk/ManagementAPI/OktaSdk/ThreatInsightAPI.swift
+++ b/Sources/OktaSdk/ManagementAPI/OktaSdk/ThreatInsightAPI.swift
@@ -34,12 +34,39 @@ public extension OktaClient {
         }
 
         /**
+         Retrieve the ThreatInsight Configuration
+         
+         - parameter completion: Completion block
+         */
+        public func getCurrentConfiguration(completion: @escaping (Result<OktaResponse<ThreatInsightConfiguration>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/threats/configuration", method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Update the ThreatInsight Configuration
          
          - parameter threatInsightConfiguration: (body)  
          */
         public func updateConfiguration(threatInsightConfiguration: ThreatInsightConfiguration) async throws -> OktaResponse<ThreatInsightConfiguration> {
             try await send(try requestWithBody(to: "/api/v1/threats/configuration", method: "POST", body: threatInsightConfiguration))
+        }
+
+        /**
+         Update the ThreatInsight Configuration
+         
+         - parameter threatInsightConfiguration: (body)  
+         - parameter completion: Completion block
+         */
+        public func updateConfiguration(threatInsightConfiguration: ThreatInsightConfiguration, completion: @escaping (Result<OktaResponse<ThreatInsightConfiguration>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/threats/configuration", method: "POST", body: threatInsightConfiguration), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
     }

--- a/Sources/OktaSdk/ManagementAPI/OktaSdk/TrustedOriginAPI.swift
+++ b/Sources/OktaSdk/ManagementAPI/OktaSdk/TrustedOriginAPI.swift
@@ -37,12 +37,42 @@ public extension OktaClient {
         }
 
         /**
+         Activate a Trusted Origin
+         
+         - parameter trustedOriginId: (path)  
+         - parameter completion: Completion block
+         */
+        public func activateOrigin(trustedOriginId: String, completion: @escaping (Result<OktaResponse<TrustedOrigin>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/trustedOrigins/{trustedOriginId}/lifecycle/activate".expanded(using: [
+                        "trustedOriginId": trustedOriginId
+                    ]), method: "POST"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Create a Trusted Origin
          
          - parameter trustedOrigin: (body)  
          */
         public func createOrigin(trustedOrigin: TrustedOrigin) async throws -> OktaResponse<TrustedOrigin> {
             try await send(try requestWithBody(to: "/api/v1/trustedOrigins", method: "POST", body: trustedOrigin))
+        }
+
+        /**
+         Create a Trusted Origin
+         
+         - parameter trustedOrigin: (body)  
+         - parameter completion: Completion block
+         */
+        public func createOrigin(trustedOrigin: TrustedOrigin, completion: @escaping (Result<OktaResponse<TrustedOrigin>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/trustedOrigins", method: "POST", body: trustedOrigin), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -54,6 +84,22 @@ public extension OktaClient {
             try await send(try request(to: "/api/v1/trustedOrigins/{trustedOriginId}/lifecycle/deactivate".expanded(using: [
                     "trustedOriginId": trustedOriginId
                 ]), method: "POST"))
+        }
+
+        /**
+         Deactivate a Trusted Origin
+         
+         - parameter trustedOriginId: (path)  
+         - parameter completion: Completion block
+         */
+        public func deactivateOrigin(trustedOriginId: String, completion: @escaping (Result<OktaResponse<TrustedOrigin>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/trustedOrigins/{trustedOriginId}/lifecycle/deactivate".expanded(using: [
+                        "trustedOriginId": trustedOriginId
+                    ]), method: "POST"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -69,6 +115,22 @@ public extension OktaClient {
         }
 
         /**
+         Delete a Trusted Origin
+         
+         - parameter trustedOriginId: (path)  
+         - parameter completion: Completion block
+         */
+        public func deleteOrigin(trustedOriginId: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/trustedOrigins/{trustedOriginId}".expanded(using: [
+                        "trustedOriginId": trustedOriginId
+                    ]), method: "DELETE"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Retrieve a Trusted Origin
          
          - parameter trustedOriginId: (path)  
@@ -77,6 +139,22 @@ public extension OktaClient {
             try await send(try request(to: "/api/v1/trustedOrigins/{trustedOriginId}".expanded(using: [
                     "trustedOriginId": trustedOriginId
                 ]), method: "GET"))
+        }
+
+        /**
+         Retrieve a Trusted Origin
+         
+         - parameter trustedOriginId: (path)  
+         - parameter completion: Completion block
+         */
+        public func getOrigin(trustedOriginId: String, completion: @escaping (Result<OktaResponse<TrustedOrigin>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/trustedOrigins/{trustedOriginId}".expanded(using: [
+                        "trustedOriginId": trustedOriginId
+                    ]), method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -97,6 +175,28 @@ public extension OktaClient {
         }
 
         /**
+         List all Trusted Origins
+         
+         - parameter q: (query)  (optional)
+         - parameter filter: (query)  (optional)
+         - parameter after: (query)  (optional)
+         - parameter limit: (query)  (optional, default to -1)
+         - parameter completion: Completion block
+         */
+        public func listOrigins(q: String? = nil, filter: String? = nil, after: String? = nil, limit: Int? = nil, completion: @escaping (Result<OktaResponse<[TrustedOrigin]>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/trustedOrigins", method: "GET", query: [
+                        "q": q, 
+                        "filter": filter, 
+                        "after": after, 
+                        "limit": limit
+                    ]), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Replace a Trusted Origin
          
          - parameter trustedOriginId: (path)  
@@ -106,6 +206,23 @@ public extension OktaClient {
             try await send(try requestWithBody(to: "/api/v1/trustedOrigins/{trustedOriginId}".expanded(using: [
                     "trustedOriginId": trustedOriginId
                 ]), method: "PUT", body: trustedOrigin))
+        }
+
+        /**
+         Replace a Trusted Origin
+         
+         - parameter trustedOriginId: (path)  
+         - parameter trustedOrigin: (body)  
+         - parameter completion: Completion block
+         */
+        public func updateOrigin(trustedOriginId: String, trustedOrigin: TrustedOrigin, completion: @escaping (Result<OktaResponse<TrustedOrigin>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/trustedOrigins/{trustedOriginId}".expanded(using: [
+                        "trustedOriginId": trustedOriginId
+                    ]), method: "PUT", body: trustedOrigin), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
     }

--- a/Sources/OktaSdk/ManagementAPI/OktaSdk/UserAPI.swift
+++ b/Sources/OktaSdk/ManagementAPI/OktaSdk/UserAPI.swift
@@ -40,6 +40,25 @@ public extension OktaClient {
         }
 
         /**
+         Activate a User
+         
+         - parameter userId: (path)  
+         - parameter sendEmail: (query) Sends an activation email to the user if true 
+         - parameter completion: Completion block
+         */
+        public func activateUser(userId: String, sendEmail: Bool, completion: @escaping (Result<OktaResponse<UserActivationToken>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/users/{userId}/lifecycle/activate".expanded(using: [
+                        "userId": userId
+                    ]), method: "POST", query: [
+                        "sendEmail": sendEmail
+                    ]), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Assign all Apps as Target to Role
          
          - parameter userId: (path)  
@@ -51,6 +70,24 @@ public extension OktaClient {
                     "userId": userId, 
                     "roleId": roleId
                 ]), method: "PUT"))
+        }
+
+        /**
+         Assign all Apps as Target to Role
+         
+         - parameter userId: (path)  
+         - parameter roleId: (path)  
+         - parameter completion: Completion block
+         */
+        public func addAllAppsAsTargetToRole(userId: String, roleId: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/users/{userId}/roles/{roleId}/targets/catalog/apps".expanded(using: [
+                        "userId": userId, 
+                        "roleId": roleId
+                    ]), method: "PUT"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -67,6 +104,26 @@ public extension OktaClient {
                     "roleId": roleId, 
                     "appName": appName
                 ]), method: "PUT"))
+        }
+
+        /**
+         Assign an Application Target to Administrator Role
+         
+         - parameter userId: (path)  
+         - parameter roleId: (path)  
+         - parameter appName: (path)  
+         - parameter completion: Completion block
+         */
+        public func addApplicationTargetToAdminRoleForUser(userId: String, roleId: String, appName: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/users/{userId}/roles/{roleId}/targets/catalog/apps/{appName}".expanded(using: [
+                        "userId": userId, 
+                        "roleId": roleId, 
+                        "appName": appName
+                    ]), method: "PUT"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -88,6 +145,28 @@ public extension OktaClient {
         }
 
         /**
+         Assign an Application Instance Target to an Application Administrator Role
+         
+         - parameter userId: (path)  
+         - parameter roleId: (path)  
+         - parameter appName: (path)  
+         - parameter applicationId: (path)  
+         - parameter completion: Completion block
+         */
+        public func addApplicationTargetToAppAdminRoleForUser(userId: String, roleId: String, appName: String, applicationId: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/users/{userId}/roles/{roleId}/targets/catalog/apps/{appName}/{applicationId}".expanded(using: [
+                        "userId": userId, 
+                        "roleId": roleId, 
+                        "appName": appName, 
+                        "applicationId": applicationId
+                    ]), method: "PUT"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Assign a Group Target to Role
          
          - parameter userId: (path)  
@@ -101,6 +180,26 @@ public extension OktaClient {
                     "roleId": roleId, 
                     "groupId": groupId
                 ]), method: "PUT"))
+        }
+
+        /**
+         Assign a Group Target to Role
+         
+         - parameter userId: (path)  
+         - parameter roleId: (path)  
+         - parameter groupId: (path)  
+         - parameter completion: Completion block
+         */
+        public func addGroupTargetToRole(userId: String, roleId: String, groupId: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/users/{userId}/roles/{roleId}/targets/groups/{groupId}".expanded(using: [
+                        "userId": userId, 
+                        "roleId": roleId, 
+                        "groupId": groupId
+                    ]), method: "PUT"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -119,6 +218,26 @@ public extension OktaClient {
         }
 
         /**
+         Assign a Role
+         
+         - parameter userId: (path)  
+         - parameter assignRoleRequest: (body)  
+         - parameter disableNotifications: (query)  (optional)
+         - parameter completion: Completion block
+         */
+        public func assignRoleToUser(userId: String, assignRoleRequest: AssignRoleRequest, disableNotifications: Bool? = nil, completion: @escaping (Result<OktaResponse<Role>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/users/{userId}/roles".expanded(using: [
+                        "userId": userId
+                    ]), method: "POST", query: [
+                        "disableNotifications": disableNotifications
+                    ], body: assignRoleRequest), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Change Password
          
          - parameter userId: (path)  
@@ -134,6 +253,26 @@ public extension OktaClient {
         }
 
         /**
+         Change Password
+         
+         - parameter userId: (path)  
+         - parameter changePasswordRequest: (body)  
+         - parameter strict: (query)  (optional)
+         - parameter completion: Completion block
+         */
+        public func changePassword(userId: String, changePasswordRequest: ChangePasswordRequest, strict: Bool? = nil, completion: @escaping (Result<OktaResponse<UserCredentials>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/users/{userId}/credentials/change_password".expanded(using: [
+                        "userId": userId
+                    ]), method: "POST", query: [
+                        "strict": strict
+                    ], body: changePasswordRequest), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Change Recovery Question
          
          - parameter userId: (path)  
@@ -143,6 +282,23 @@ public extension OktaClient {
             try await send(try requestWithBody(to: "/api/v1/users/{userId}/credentials/change_recovery_question".expanded(using: [
                     "userId": userId
                 ]), method: "POST", body: userCredentials))
+        }
+
+        /**
+         Change Recovery Question
+         
+         - parameter userId: (path)  
+         - parameter userCredentials: (body)  
+         - parameter completion: Completion block
+         */
+        public func changeRecoveryQuestion(userId: String, userCredentials: UserCredentials, completion: @escaping (Result<OktaResponse<UserCredentials>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/users/{userId}/credentials/change_recovery_question".expanded(using: [
+                        "userId": userId
+                    ]), method: "POST", body: userCredentials), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -158,6 +314,25 @@ public extension OktaClient {
                 ]), method: "DELETE", query: [
                     "oauthTokens": oauthTokens
                 ]))
+        }
+
+        /**
+         Delete all User Sessions
+         
+         - parameter userId: (path)  
+         - parameter oauthTokens: (query) Revoke issued OpenID Connect and OAuth refresh and access tokens (optional, default to false)
+         - parameter completion: Completion block
+         */
+        public func clearUserSessions(userId: String, oauthTokens: Bool? = nil, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/users/{userId}/sessions".expanded(using: [
+                        "userId": userId
+                    ]), method: "DELETE", query: [
+                        "oauthTokens": oauthTokens
+                    ]), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -177,6 +352,27 @@ public extension OktaClient {
         }
 
         /**
+         Create a User
+         
+         - parameter body: (body)  
+         - parameter activate: (query) Executes activation lifecycle operation when creating the user (optional, default to true)
+         - parameter provider: (query) Indicates whether to create a user with a specified authentication provider (optional, default to false)
+         - parameter nextLogin: (query) With activate&#x3D;true, set nextLogin to \&quot;changePassword\&quot; to have the password be EXPIRED, so user must change it the next time they log in. (optional)
+         - parameter completion: Completion block
+         */
+        public func createUser(body: CreateUserRequest, activate: Bool? = nil, provider: Bool? = nil, nextLogin: UserNextLogin? = nil, completion: @escaping (Result<OktaResponse<User>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/users", method: "POST", query: [
+                        "activate": activate, 
+                        "provider": provider, 
+                        "nextLogin": nextLogin
+                    ], body: body), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Delete a User
          
          - parameter userId: (path)  
@@ -189,6 +385,25 @@ public extension OktaClient {
                 ]), method: "DELETE", query: [
                     "sendEmail": sendEmail
                 ]))
+        }
+
+        /**
+         Delete a User
+         
+         - parameter userId: (path)  
+         - parameter sendEmail: (query)  (optional, default to false)
+         - parameter completion: Completion block
+         */
+        public func deactivateOrDeleteUser(userId: String, sendEmail: Bool? = nil, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/users/{userId}".expanded(using: [
+                        "userId": userId
+                    ]), method: "DELETE", query: [
+                        "sendEmail": sendEmail
+                    ]), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -207,6 +422,25 @@ public extension OktaClient {
         }
 
         /**
+         Deactivate a User
+         
+         - parameter userId: (path)  
+         - parameter sendEmail: (query)  (optional, default to false)
+         - parameter completion: Completion block
+         */
+        public func deactivateUser(userId: String, sendEmail: Bool? = nil, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/users/{userId}/lifecycle/deactivate".expanded(using: [
+                        "userId": userId
+                    ]), method: "POST", query: [
+                        "sendEmail": sendEmail
+                    ]), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Expire Password
          
          - parameter userId: (path)  
@@ -215,6 +449,22 @@ public extension OktaClient {
             try await send(try request(to: "/api/v1/users/{userId}/lifecycle/expire_password".expanded(using: [
                     "userId": userId
                 ]), method: "POST"))
+        }
+
+        /**
+         Expire Password
+         
+         - parameter userId: (path)  
+         - parameter completion: Completion block
+         */
+        public func expirePassword(userId: String, completion: @escaping (Result<OktaResponse<User>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/users/{userId}/lifecycle/expire_password".expanded(using: [
+                        "userId": userId
+                    ]), method: "POST"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -229,6 +479,22 @@ public extension OktaClient {
         }
 
         /**
+         Expire Password and Set Temporary Password
+         
+         - parameter userId: (path)  
+         - parameter completion: Completion block
+         */
+        public func expirePasswordAndGetTemporaryPassword(userId: String, completion: @escaping (Result<OktaResponse<TempPassword>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/users/{userId}/lifecycle/expire_password_with_temp_password".expanded(using: [
+                        "userId": userId
+                    ]), method: "POST"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Initiate Forgot Password
          
          - parameter userId: (path)  
@@ -240,6 +506,25 @@ public extension OktaClient {
                 ]), method: "POST", query: [
                     "sendEmail": sendEmail
                 ]))
+        }
+
+        /**
+         Initiate Forgot Password
+         
+         - parameter userId: (path)  
+         - parameter sendEmail: (query)  (optional, default to true)
+         - parameter completion: Completion block
+         */
+        public func forgotPassword(userId: String, sendEmail: Bool? = nil, completion: @escaping (Result<OktaResponse<ForgotPasswordResponse>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/users/{userId}/credentials/forgot_password".expanded(using: [
+                        "userId": userId
+                    ]), method: "POST", query: [
+                        "sendEmail": sendEmail
+                    ]), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -258,6 +543,26 @@ public extension OktaClient {
         }
 
         /**
+         Reset Password with Recovery Question
+         
+         - parameter userId: (path)  
+         - parameter userCredentials: (body)  
+         - parameter sendEmail: (query)  (optional, default to true)
+         - parameter completion: Completion block
+         */
+        public func forgotPasswordSetNewPassword(userId: String, userCredentials: UserCredentials, sendEmail: Bool? = nil, completion: @escaping (Result<OktaResponse<UserCredentials>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/users/{userId}/credentials/forgot_password_recovery_question".expanded(using: [
+                        "userId": userId
+                    ]), method: "POST", query: [
+                        "sendEmail": sendEmail
+                    ], body: userCredentials), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          List all Linked Objects
          
          - parameter userId: (path)  
@@ -273,6 +578,29 @@ public extension OktaClient {
                     "after": after, 
                     "limit": limit
                 ]))
+        }
+
+        /**
+         List all Linked Objects
+         
+         - parameter userId: (path)  
+         - parameter relationshipName: (path)  
+         - parameter after: (query)  (optional)
+         - parameter limit: (query)  (optional, default to -1)
+         - parameter completion: Completion block
+         */
+        public func getLinkedObjectsForUser(userId: String, relationshipName: String, after: String? = nil, limit: Int? = nil, completion: @escaping (Result<OktaResponse<[AnyCodable]>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/users/{userId}/linkedObjects/{relationshipName}".expanded(using: [
+                        "userId": userId, 
+                        "relationshipName": relationshipName
+                    ]), method: "GET", query: [
+                        "after": after, 
+                        "limit": limit
+                    ]), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -298,6 +626,33 @@ public extension OktaClient {
         }
 
         /**
+         Retrieve a Refresh Token for a Client
+         
+         - parameter userId: (path)  
+         - parameter clientId: (path)  
+         - parameter tokenId: (path)  
+         - parameter expand: (query)  (optional)
+         - parameter limit: (query)  (optional, default to 20)
+         - parameter after: (query)  (optional)
+         - parameter completion: Completion block
+         */
+        public func getRefreshTokenForUserAndClient(userId: String, clientId: String, tokenId: String, expand: String? = nil, limit: Int? = nil, after: String? = nil, completion: @escaping (Result<OktaResponse<OAuth2RefreshToken>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/users/{userId}/clients/{clientId}/tokens/{tokenId}".expanded(using: [
+                        "userId": userId, 
+                        "clientId": clientId, 
+                        "tokenId": tokenId
+                    ]), method: "GET", query: [
+                        "expand": expand, 
+                        "limit": limit, 
+                        "after": after
+                    ]), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Retrieve a User
          
          - parameter userId: (path)  
@@ -306,6 +661,22 @@ public extension OktaClient {
             try await send(try request(to: "/api/v1/users/{userId}".expanded(using: [
                     "userId": userId
                 ]), method: "GET"))
+        }
+
+        /**
+         Retrieve a User
+         
+         - parameter userId: (path)  
+         - parameter completion: Completion block
+         */
+        public func getUser(userId: String, completion: @escaping (Result<OktaResponse<User>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/users/{userId}".expanded(using: [
+                        "userId": userId
+                    ]), method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -325,6 +696,27 @@ public extension OktaClient {
         }
 
         /**
+         Retrieve a User Grant
+         
+         - parameter userId: (path)  
+         - parameter grantId: (path)  
+         - parameter expand: (query)  (optional)
+         - parameter completion: Completion block
+         */
+        public func getUserGrant(userId: String, grantId: String, expand: String? = nil, completion: @escaping (Result<OktaResponse<OAuth2ScopeConsentGrant>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/users/{userId}/grants/{grantId}".expanded(using: [
+                        "userId": userId, 
+                        "grantId": grantId
+                    ]), method: "GET", query: [
+                        "expand": expand
+                    ]), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Retrieve a Role
          
          - parameter userId: (path)  
@@ -338,6 +730,24 @@ public extension OktaClient {
         }
 
         /**
+         Retrieve a Role
+         
+         - parameter userId: (path)  
+         - parameter roleId: (path)  
+         - parameter completion: Completion block
+         */
+        public func getUserRole(userId: String, roleId: String, completion: @escaping (Result<OktaResponse<Role>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/users/{userId}/roles/{roleId}".expanded(using: [
+                        "userId": userId, 
+                        "roleId": roleId
+                    ]), method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          List all Assigned Application Links
          
          - parameter userId: (path)  
@@ -346,6 +756,22 @@ public extension OktaClient {
             try await send(try request(to: "/api/v1/users/{userId}/appLinks".expanded(using: [
                     "userId": userId
                 ]), method: "GET"))
+        }
+
+        /**
+         List all Assigned Application Links
+         
+         - parameter userId: (path)  
+         - parameter completion: Completion block
+         */
+        public func listAppLinks(userId: String, completion: @escaping (Result<OktaResponse<[AppLink]>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/users/{userId}/appLinks".expanded(using: [
+                        "userId": userId
+                    ]), method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -367,6 +793,29 @@ public extension OktaClient {
         }
 
         /**
+         List all Application Targets for Application Administrator Role
+         
+         - parameter userId: (path)  
+         - parameter roleId: (path)  
+         - parameter after: (query)  (optional)
+         - parameter limit: (query)  (optional, default to 20)
+         - parameter completion: Completion block
+         */
+        public func listApplicationTargetsForApplicationAdministratorRoleForUser(userId: String, roleId: String, after: String? = nil, limit: Int? = nil, completion: @escaping (Result<OktaResponse<[CatalogApplication]>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/users/{userId}/roles/{roleId}/targets/catalog/apps".expanded(using: [
+                        "userId": userId, 
+                        "roleId": roleId
+                    ]), method: "GET", query: [
+                        "after": after, 
+                        "limit": limit
+                    ]), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          List all Assigned Roles
          
          - parameter userId: (path)  
@@ -378,6 +827,25 @@ public extension OktaClient {
                 ]), method: "GET", query: [
                     "expand": expand
                 ]))
+        }
+
+        /**
+         List all Assigned Roles
+         
+         - parameter userId: (path)  
+         - parameter expand: (query)  (optional)
+         - parameter completion: Completion block
+         */
+        public func listAssignedRolesForUser(userId: String, expand: String? = nil, completion: @escaping (Result<OktaResponse<[Role]>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/users/{userId}/roles".expanded(using: [
+                        "userId": userId
+                    ]), method: "GET", query: [
+                        "expand": expand
+                    ]), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -401,6 +869,31 @@ public extension OktaClient {
         }
 
         /**
+         List all Grants for a Client
+         
+         - parameter userId: (path)  
+         - parameter clientId: (path)  
+         - parameter expand: (query)  (optional)
+         - parameter after: (query)  (optional)
+         - parameter limit: (query)  (optional, default to 20)
+         - parameter completion: Completion block
+         */
+        public func listGrantsForUserAndClient(userId: String, clientId: String, expand: String? = nil, after: String? = nil, limit: Int? = nil, completion: @escaping (Result<OktaResponse<[OAuth2ScopeConsentGrant]>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/users/{userId}/clients/{clientId}/grants".expanded(using: [
+                        "userId": userId, 
+                        "clientId": clientId
+                    ]), method: "GET", query: [
+                        "expand": expand, 
+                        "after": after, 
+                        "limit": limit
+                    ]), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          List all Group Targets for Role
          
          - parameter userId: (path)  
@@ -416,6 +909,29 @@ public extension OktaClient {
                     "after": after, 
                     "limit": limit
                 ]))
+        }
+
+        /**
+         List all Group Targets for Role
+         
+         - parameter userId: (path)  
+         - parameter roleId: (path)  
+         - parameter after: (query)  (optional)
+         - parameter limit: (query)  (optional, default to 20)
+         - parameter completion: Completion block
+         */
+        public func listGroupTargetsForRole(userId: String, roleId: String, after: String? = nil, limit: Int? = nil, completion: @escaping (Result<OktaResponse<[Group]>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/users/{userId}/roles/{roleId}/targets/groups".expanded(using: [
+                        "userId": userId, 
+                        "roleId": roleId
+                    ]), method: "GET", query: [
+                        "after": after, 
+                        "limit": limit
+                    ]), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -439,6 +955,31 @@ public extension OktaClient {
         }
 
         /**
+         List all Refresh Tokens for a Client
+         
+         - parameter userId: (path)  
+         - parameter clientId: (path)  
+         - parameter expand: (query)  (optional)
+         - parameter after: (query)  (optional)
+         - parameter limit: (query)  (optional, default to 20)
+         - parameter completion: Completion block
+         */
+        public func listRefreshTokensForUserAndClient(userId: String, clientId: String, expand: String? = nil, after: String? = nil, limit: Int? = nil, completion: @escaping (Result<OktaResponse<[OAuth2RefreshToken]>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/users/{userId}/clients/{clientId}/tokens".expanded(using: [
+                        "userId": userId, 
+                        "clientId": clientId
+                    ]), method: "GET", query: [
+                        "expand": expand, 
+                        "after": after, 
+                        "limit": limit
+                    ]), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          List all Clients
          
          - parameter userId: (path)  
@@ -447,6 +988,22 @@ public extension OktaClient {
             try await send(try request(to: "/api/v1/users/{userId}/clients".expanded(using: [
                     "userId": userId
                 ]), method: "GET"))
+        }
+
+        /**
+         List all Clients
+         
+         - parameter userId: (path)  
+         - parameter completion: Completion block
+         */
+        public func listUserClients(userId: String, completion: @escaping (Result<OktaResponse<[OAuth2Client]>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/users/{userId}/clients".expanded(using: [
+                        "userId": userId
+                    ]), method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -470,6 +1027,31 @@ public extension OktaClient {
         }
 
         /**
+         List all User Grants
+         
+         - parameter userId: (path)  
+         - parameter scopeId: (query)  (optional)
+         - parameter expand: (query)  (optional)
+         - parameter after: (query)  (optional)
+         - parameter limit: (query)  (optional, default to 20)
+         - parameter completion: Completion block
+         */
+        public func listUserGrants(userId: String, scopeId: String? = nil, expand: String? = nil, after: String? = nil, limit: Int? = nil, completion: @escaping (Result<OktaResponse<[OAuth2ScopeConsentGrant]>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/users/{userId}/grants".expanded(using: [
+                        "userId": userId
+                    ]), method: "GET", query: [
+                        "scopeId": scopeId, 
+                        "expand": expand, 
+                        "after": after, 
+                        "limit": limit
+                    ]), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          List all Groups
          
          - parameter userId: (path)  
@@ -481,6 +1063,22 @@ public extension OktaClient {
         }
 
         /**
+         List all Groups
+         
+         - parameter userId: (path)  
+         - parameter completion: Completion block
+         */
+        public func listUserGroups(userId: String, completion: @escaping (Result<OktaResponse<[Group]>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/users/{userId}/groups".expanded(using: [
+                        "userId": userId
+                    ]), method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          List all Identity Providers
          
          - parameter userId: (path)  
@@ -489,6 +1087,22 @@ public extension OktaClient {
             try await send(try request(to: "/api/v1/users/{userId}/idps".expanded(using: [
                     "userId": userId
                 ]), method: "GET"))
+        }
+
+        /**
+         List all Identity Providers
+         
+         - parameter userId: (path)  
+         - parameter completion: Completion block
+         */
+        public func listUserIdentityProviders(userId: String, completion: @escaping (Result<OktaResponse<[IdentityProvider]>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/users/{userId}/idps".expanded(using: [
+                        "userId": userId
+                    ]), method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -515,6 +1129,34 @@ public extension OktaClient {
         }
 
         /**
+         List all Users
+         
+         - parameter after: (query) The cursor to use for pagination. It is an opaque string that specifies your current location in the list and is obtained from the &#x60;Link&#x60; response header. See [Pagination](https://developer.okta.com/docs/reference/core-okta-api/#pagination) for more information. (optional)
+         - parameter q: (query) Finds a user that matches firstName, lastName, and email properties (optional)
+         - parameter limit: (query) Specifies the number of results returned. Defaults to 10 if &#x60;q&#x60; is provided. (optional, default to 200)
+         - parameter filter: (query) Filters users with a supported expression for a subset of properties (optional)
+         - parameter search: (query) Searches for users with a supported filtering  expression for most properties (optional)
+         - parameter sortBy: (query)  (optional)
+         - parameter sortOrder: (query)  (optional)
+         - parameter completion: Completion block
+         */
+        public func listUsers(after: String? = nil, q: String? = nil, limit: Int? = nil, filter: String? = nil, search: String? = nil, sortBy: String? = nil, sortOrder: String? = nil, completion: @escaping (Result<OktaResponse<[User]>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/users", method: "GET", query: [
+                        "after": after, 
+                        "q": q, 
+                        "limit": limit, 
+                        "filter": filter, 
+                        "search": search, 
+                        "sortBy": sortBy, 
+                        "sortOrder": sortOrder
+                    ]), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Update a User
          
          - parameter userId: (path)  
@@ -530,6 +1172,26 @@ public extension OktaClient {
         }
 
         /**
+         Update a User
+         
+         - parameter userId: (path)  
+         - parameter user: (body)  
+         - parameter strict: (query)  (optional)
+         - parameter completion: Completion block
+         */
+        public func partialUpdateUser(userId: String, user: UpdateUserRequest, strict: Bool? = nil, completion: @escaping (Result<OktaResponse<User>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/users/{userId}".expanded(using: [
+                        "userId": userId
+                    ]), method: "POST", query: [
+                        "strict": strict
+                    ], body: user), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Reactivate a User
          
          - parameter userId: (path)  
@@ -541,6 +1203,25 @@ public extension OktaClient {
                 ]), method: "POST", query: [
                     "sendEmail": sendEmail
                 ]))
+        }
+
+        /**
+         Reactivate a User
+         
+         - parameter userId: (path)  
+         - parameter sendEmail: (query) Sends an activation email to the user if true (optional, default to false)
+         - parameter completion: Completion block
+         */
+        public func reactivateUser(userId: String, sendEmail: Bool? = nil, completion: @escaping (Result<OktaResponse<UserActivationToken>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/users/{userId}/lifecycle/reactivate".expanded(using: [
+                        "userId": userId
+                    ]), method: "POST", query: [
+                        "sendEmail": sendEmail
+                    ]), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -562,6 +1243,28 @@ public extension OktaClient {
         }
 
         /**
+         Unassign an Application Instance Target to Application Administrator Role
+         
+         - parameter userId: (path)  
+         - parameter roleId: (path)  
+         - parameter appName: (path)  
+         - parameter applicationId: (path)  
+         - parameter completion: Completion block
+         */
+        public func removeApplicationTargetFromAdministratorRoleForUser(userId: String, roleId: String, appName: String, applicationId: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/users/{userId}/roles/{roleId}/targets/catalog/apps/{appName}/{applicationId}".expanded(using: [
+                        "userId": userId, 
+                        "roleId": roleId, 
+                        "appName": appName, 
+                        "applicationId": applicationId
+                    ]), method: "DELETE"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Unassign an Application Target from Application Administrator Role
          
          - parameter userId: (path)  
@@ -575,6 +1278,26 @@ public extension OktaClient {
                     "roleId": roleId, 
                     "appName": appName
                 ]), method: "DELETE"))
+        }
+
+        /**
+         Unassign an Application Target from Application Administrator Role
+         
+         - parameter userId: (path)  
+         - parameter roleId: (path)  
+         - parameter appName: (path)  
+         - parameter completion: Completion block
+         */
+        public func removeApplicationTargetFromApplicationAdministratorRoleForUser(userId: String, roleId: String, appName: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/users/{userId}/roles/{roleId}/targets/catalog/apps/{appName}".expanded(using: [
+                        "userId": userId, 
+                        "roleId": roleId, 
+                        "appName": appName
+                    ]), method: "DELETE"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -594,6 +1317,26 @@ public extension OktaClient {
         }
 
         /**
+         Unassign a Group Target from Role
+         
+         - parameter userId: (path)  
+         - parameter roleId: (path)  
+         - parameter groupId: (path)  
+         - parameter completion: Completion block
+         */
+        public func removeGroupTargetFromRole(userId: String, roleId: String, groupId: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/users/{userId}/roles/{roleId}/targets/groups/{groupId}".expanded(using: [
+                        "userId": userId, 
+                        "roleId": roleId, 
+                        "groupId": groupId
+                    ]), method: "DELETE"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Delete a Linked Object
          
          - parameter userId: (path)  
@@ -605,6 +1348,24 @@ public extension OktaClient {
                     "userId": userId, 
                     "relationshipName": relationshipName
                 ]), method: "DELETE"))
+        }
+
+        /**
+         Delete a Linked Object
+         
+         - parameter userId: (path)  
+         - parameter relationshipName: (path)  
+         - parameter completion: Completion block
+         */
+        public func removeLinkedObjectForUser(userId: String, relationshipName: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/users/{userId}/linkedObjects/{relationshipName}".expanded(using: [
+                        "userId": userId, 
+                        "relationshipName": relationshipName
+                    ]), method: "DELETE"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -622,6 +1383,24 @@ public extension OktaClient {
         }
 
         /**
+         Delete a Role
+         
+         - parameter userId: (path)  
+         - parameter roleId: (path)  
+         - parameter completion: Completion block
+         */
+        public func removeRoleFromUser(userId: String, roleId: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/users/{userId}/roles/{roleId}".expanded(using: [
+                        "userId": userId, 
+                        "roleId": roleId
+                    ]), method: "DELETE"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Reset all Factors
          
          - parameter userId: (path)  
@@ -631,6 +1410,22 @@ public extension OktaClient {
             try await send(try request(to: "/api/v1/users/{userId}/lifecycle/reset_factors".expanded(using: [
                     "userId": userId
                 ]), method: "POST"))
+        }
+
+        /**
+         Reset all Factors
+         
+         - parameter userId: (path)  
+         - parameter completion: Completion block
+         */
+        public func resetFactors(userId: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/users/{userId}/lifecycle/reset_factors".expanded(using: [
+                        "userId": userId
+                    ]), method: "POST"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -648,6 +1443,25 @@ public extension OktaClient {
         }
 
         /**
+         Reset Password
+         
+         - parameter userId: (path)  
+         - parameter sendEmail: (query)  
+         - parameter completion: Completion block
+         */
+        public func resetPassword(userId: String, sendEmail: Bool, completion: @escaping (Result<OktaResponse<ResetPasswordToken>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/users/{userId}/lifecycle/reset_password".expanded(using: [
+                        "userId": userId
+                    ]), method: "POST", query: [
+                        "sendEmail": sendEmail
+                    ]), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Revoke all Grants for a Client
          
          - parameter userId: (path)  
@@ -659,6 +1473,24 @@ public extension OktaClient {
                     "userId": userId, 
                     "clientId": clientId
                 ]), method: "DELETE"))
+        }
+
+        /**
+         Revoke all Grants for a Client
+         
+         - parameter userId: (path)  
+         - parameter clientId: (path)  
+         - parameter completion: Completion block
+         */
+        public func revokeGrantsForUserAndClient(userId: String, clientId: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/users/{userId}/clients/{clientId}/grants".expanded(using: [
+                        "userId": userId, 
+                        "clientId": clientId
+                    ]), method: "DELETE"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -678,6 +1510,26 @@ public extension OktaClient {
         }
 
         /**
+         Revoke a Token for a Client
+         
+         - parameter userId: (path)  
+         - parameter clientId: (path)  
+         - parameter tokenId: (path)  
+         - parameter completion: Completion block
+         */
+        public func revokeTokenForUserAndClient(userId: String, clientId: String, tokenId: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/users/{userId}/clients/{clientId}/tokens/{tokenId}".expanded(using: [
+                        "userId": userId, 
+                        "clientId": clientId, 
+                        "tokenId": tokenId
+                    ]), method: "DELETE"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Revoke all Refresh Tokens for a Client
          
          - parameter userId: (path)  
@@ -689,6 +1541,24 @@ public extension OktaClient {
                     "userId": userId, 
                     "clientId": clientId
                 ]), method: "DELETE"))
+        }
+
+        /**
+         Revoke all Refresh Tokens for a Client
+         
+         - parameter userId: (path)  
+         - parameter clientId: (path)  
+         - parameter completion: Completion block
+         */
+        public func revokeTokensForUserAndClient(userId: String, clientId: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/users/{userId}/clients/{clientId}/tokens".expanded(using: [
+                        "userId": userId, 
+                        "clientId": clientId
+                    ]), method: "DELETE"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -706,6 +1576,24 @@ public extension OktaClient {
         }
 
         /**
+         Revoke a User Grant
+         
+         - parameter userId: (path)  
+         - parameter grantId: (path)  
+         - parameter completion: Completion block
+         */
+        public func revokeUserGrant(userId: String, grantId: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/users/{userId}/grants/{grantId}".expanded(using: [
+                        "userId": userId, 
+                        "grantId": grantId
+                    ]), method: "DELETE"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Revoke all User Grants
          
          - parameter userId: (path)  
@@ -715,6 +1603,22 @@ public extension OktaClient {
             try await send(try request(to: "/api/v1/users/{userId}/grants".expanded(using: [
                     "userId": userId
                 ]), method: "DELETE"))
+        }
+
+        /**
+         Revoke all User Grants
+         
+         - parameter userId: (path)  
+         - parameter completion: Completion block
+         */
+        public func revokeUserGrants(userId: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/users/{userId}/grants".expanded(using: [
+                        "userId": userId
+                    ]), method: "DELETE"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -734,6 +1638,26 @@ public extension OktaClient {
         }
 
         /**
+         Create a Linked Object for two User
+         
+         - parameter associatedUserId: (path)  
+         - parameter primaryRelationshipName: (path)  
+         - parameter primaryUserId: (path)  
+         - parameter completion: Completion block
+         */
+        public func setLinkedObjectForUser(associatedUserId: String, primaryRelationshipName: String, primaryUserId: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/users/{associatedUserId}/linkedObjects/{primaryRelationshipName}/{primaryUserId}".expanded(using: [
+                        "associatedUserId": associatedUserId, 
+                        "primaryRelationshipName": primaryRelationshipName, 
+                        "primaryUserId": primaryUserId
+                    ]), method: "PUT"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Suspend a User
          
          - parameter userId: (path)  
@@ -743,6 +1667,22 @@ public extension OktaClient {
             try await send(try request(to: "/api/v1/users/{userId}/lifecycle/suspend".expanded(using: [
                     "userId": userId
                 ]), method: "POST"))
+        }
+
+        /**
+         Suspend a User
+         
+         - parameter userId: (path)  
+         - parameter completion: Completion block
+         */
+        public func suspendUser(userId: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/users/{userId}/lifecycle/suspend".expanded(using: [
+                        "userId": userId
+                    ]), method: "POST"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -758,6 +1698,22 @@ public extension OktaClient {
         }
 
         /**
+         Unlock a User
+         
+         - parameter userId: (path)  
+         - parameter completion: Completion block
+         */
+        public func unlockUser(userId: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/users/{userId}/lifecycle/unlock".expanded(using: [
+                        "userId": userId
+                    ]), method: "POST"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Unsuspend a User
          
          - parameter userId: (path)  
@@ -767,6 +1723,22 @@ public extension OktaClient {
             try await send(try request(to: "/api/v1/users/{userId}/lifecycle/unsuspend".expanded(using: [
                     "userId": userId
                 ]), method: "POST"))
+        }
+
+        /**
+         Unsuspend a User
+         
+         - parameter userId: (path)  
+         - parameter completion: Completion block
+         */
+        public func unsuspendUser(userId: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/users/{userId}/lifecycle/unsuspend".expanded(using: [
+                        "userId": userId
+                    ]), method: "POST"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -782,6 +1754,26 @@ public extension OktaClient {
                 ]), method: "PUT", query: [
                     "strict": strict
                 ], body: user))
+        }
+
+        /**
+         Replace a User
+         
+         - parameter userId: (path)  
+         - parameter user: (body)  
+         - parameter strict: (query)  (optional)
+         - parameter completion: Completion block
+         */
+        public func updateUser(userId: String, user: UpdateUserRequest, strict: Bool? = nil, completion: @escaping (Result<OktaResponse<User>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/users/{userId}".expanded(using: [
+                        "userId": userId
+                    ]), method: "PUT", query: [
+                        "strict": strict
+                    ], body: user), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
     }

--- a/Sources/OktaSdk/ManagementAPI/OktaSdk/UserFactorAPI.swift
+++ b/Sources/OktaSdk/ManagementAPI/OktaSdk/UserFactorAPI.swift
@@ -40,6 +40,25 @@ public extension OktaClient {
         }
 
         /**
+         Activate a Factor
+         
+         - parameter userId: (path)  
+         - parameter factorId: (path)  
+         - parameter body: (body)  (optional)
+         - parameter completion: Completion block
+         */
+        public func activateFactor(userId: String, factorId: String, body: ActivateFactorRequest? = nil, completion: @escaping (Result<OktaResponse<UserFactor>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/users/{userId}/factors/{factorId}/lifecycle/activate".expanded(using: [
+                        "userId": userId, 
+                        "factorId": factorId
+                    ]), method: "POST", body: body), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Delete a Factor
          
          - parameter userId: (path)  
@@ -54,6 +73,27 @@ public extension OktaClient {
                 ]), method: "DELETE", query: [
                     "removeEnrollmentRecovery": removeEnrollmentRecovery
                 ]))
+        }
+
+        /**
+         Delete a Factor
+         
+         - parameter userId: (path)  
+         - parameter factorId: (path)  
+         - parameter removeEnrollmentRecovery: (query)  (optional, default to false)
+         - parameter completion: Completion block
+         */
+        public func deleteFactor(userId: String, factorId: String, removeEnrollmentRecovery: Bool? = nil, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/users/{userId}/factors/{factorId}".expanded(using: [
+                        "userId": userId, 
+                        "factorId": factorId
+                    ]), method: "DELETE", query: [
+                        "removeEnrollmentRecovery": removeEnrollmentRecovery
+                    ]), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -78,6 +118,32 @@ public extension OktaClient {
         }
 
         /**
+         Enroll a Factor
+         
+         - parameter userId: (path)  
+         - parameter body: (body) Factor 
+         - parameter updatePhone: (query)  (optional, default to false)
+         - parameter templateId: (query) id of SMS template (only for SMS factor) (optional)
+         - parameter tokenLifetimeSeconds: (query)  (optional, default to 300)
+         - parameter activate: (query)  (optional, default to false)
+         - parameter completion: Completion block
+         */
+        public func enrollFactor(userId: String, body: UserFactor, updatePhone: Bool? = nil, templateId: String? = nil, tokenLifetimeSeconds: Int? = nil, activate: Bool? = nil, completion: @escaping (Result<OktaResponse<UserFactor>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/users/{userId}/factors".expanded(using: [
+                        "userId": userId
+                    ]), method: "POST", query: [
+                        "updatePhone": updatePhone, 
+                        "templateId": templateId, 
+                        "tokenLifetimeSeconds": tokenLifetimeSeconds, 
+                        "activate": activate
+                    ], body: body), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Retrieve a Factor
          
          - parameter userId: (path)  
@@ -88,6 +154,24 @@ public extension OktaClient {
                     "userId": userId, 
                     "factorId": factorId
                 ]), method: "GET"))
+        }
+
+        /**
+         Retrieve a Factor
+         
+         - parameter userId: (path)  
+         - parameter factorId: (path)  
+         - parameter completion: Completion block
+         */
+        public func getFactor(userId: String, factorId: String, completion: @escaping (Result<OktaResponse<UserFactor>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/users/{userId}/factors/{factorId}".expanded(using: [
+                        "userId": userId, 
+                        "factorId": factorId
+                    ]), method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -106,6 +190,26 @@ public extension OktaClient {
         }
 
         /**
+         Retrieve a Factor Transaction Status
+         
+         - parameter userId: (path)  
+         - parameter factorId: (path)  
+         - parameter transactionId: (path)  
+         - parameter completion: Completion block
+         */
+        public func getFactorTransactionStatus(userId: String, factorId: String, transactionId: String, completion: @escaping (Result<OktaResponse<VerifyUserFactorResponse>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/users/{userId}/factors/{factorId}/transactions/{transactionId}".expanded(using: [
+                        "userId": userId, 
+                        "factorId": factorId, 
+                        "transactionId": transactionId
+                    ]), method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          List all Factors
          
          - parameter userId: (path)  
@@ -114,6 +218,22 @@ public extension OktaClient {
             try await send(try request(to: "/api/v1/users/{userId}/factors".expanded(using: [
                     "userId": userId
                 ]), method: "GET"))
+        }
+
+        /**
+         List all Factors
+         
+         - parameter userId: (path)  
+         - parameter completion: Completion block
+         */
+        public func listFactors(userId: String, completion: @escaping (Result<OktaResponse<[UserFactor]>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/users/{userId}/factors".expanded(using: [
+                        "userId": userId
+                    ]), method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -128,6 +248,22 @@ public extension OktaClient {
         }
 
         /**
+         List all Supported Factors
+         
+         - parameter userId: (path)  
+         - parameter completion: Completion block
+         */
+        public func listSupportedFactors(userId: String, completion: @escaping (Result<OktaResponse<[UserFactor]>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/users/{userId}/factors/catalog".expanded(using: [
+                        "userId": userId
+                    ]), method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          List all Supported Security Questions
          
          - parameter userId: (path)  
@@ -136,6 +272,22 @@ public extension OktaClient {
             try await send(try request(to: "/api/v1/users/{userId}/factors/questions".expanded(using: [
                     "userId": userId
                 ]), method: "GET"))
+        }
+
+        /**
+         List all Supported Security Questions
+         
+         - parameter userId: (path)  
+         - parameter completion: Completion block
+         */
+        public func listSupportedSecurityQuestions(userId: String, completion: @escaping (Result<OktaResponse<[SecurityQuestion]>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/users/{userId}/factors/questions".expanded(using: [
+                        "userId": userId
+                    ]), method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -162,6 +314,37 @@ public extension OktaClient {
                     "userAgent": userAgent?.stringValue, 
                     "acceptLanguage": acceptLanguage?.stringValue
                 ], body: body))
+        }
+
+        /**
+         Verify an MFA Factor
+         
+         - parameter userId: (path)  
+         - parameter factorId: (path)  
+         - parameter templateId: (query)  (optional)
+         - parameter tokenLifetimeSeconds: (query)  (optional, default to 300)
+         - parameter xForwardedFor: (header)  (optional)
+         - parameter userAgent: (header)  (optional)
+         - parameter acceptLanguage: (header)  (optional)
+         - parameter body: (body)  (optional)
+         - parameter completion: Completion block
+         */
+        public func verifyFactor(userId: String, factorId: String, templateId: String? = nil, tokenLifetimeSeconds: Int? = nil, xForwardedFor: String? = nil, userAgent: String? = nil, acceptLanguage: String? = nil, body: VerifyFactorRequest? = nil, completion: @escaping (Result<OktaResponse<VerifyUserFactorResponse>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/users/{userId}/factors/{factorId}/verify".expanded(using: [
+                        "userId": userId, 
+                        "factorId": factorId
+                    ]), method: "POST", query: [
+                        "templateId": templateId, 
+                        "tokenLifetimeSeconds": tokenLifetimeSeconds
+                    ], headers: [
+                        "xForwardedFor": xForwardedFor?.stringValue, 
+                        "userAgent": userAgent?.stringValue, 
+                        "acceptLanguage": acceptLanguage?.stringValue
+                    ], body: body), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
     }

--- a/Sources/OktaSdk/ManagementAPI/OktaSdk/UserTypeAPI.swift
+++ b/Sources/OktaSdk/ManagementAPI/OktaSdk/UserTypeAPI.swift
@@ -35,6 +35,20 @@ public extension OktaClient {
         }
 
         /**
+         Create a User Type
+         
+         - parameter userType: (body)  
+         - parameter completion: Completion block
+         */
+        public func createUserType(userType: UserType, completion: @escaping (Result<OktaResponse<UserType>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/meta/types/user", method: "POST", body: userType), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Delete a User Type
          
          - parameter typeId: (path)  
@@ -44,6 +58,22 @@ public extension OktaClient {
             try await send(try request(to: "/api/v1/meta/types/user/{typeId}".expanded(using: [
                     "typeId": typeId
                 ]), method: "DELETE"))
+        }
+
+        /**
+         Delete a User Type
+         
+         - parameter typeId: (path)  
+         - parameter completion: Completion block
+         */
+        public func deleteUserType(typeId: String, completion: @escaping (Result<OktaResponse<Empty>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/meta/types/user/{typeId}".expanded(using: [
+                        "typeId": typeId
+                    ]), method: "DELETE"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -58,11 +88,40 @@ public extension OktaClient {
         }
 
         /**
+         Retrieve a User Type
+         
+         - parameter typeId: (path)  
+         - parameter completion: Completion block
+         */
+        public func getUserType(typeId: String, completion: @escaping (Result<OktaResponse<UserType>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/meta/types/user/{typeId}".expanded(using: [
+                        "typeId": typeId
+                    ]), method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          List all User Types
          
          */
         public func listUserTypes() async throws -> OktaResponse<[UserType]> {
             try await send(try request(to: "/api/v1/meta/types/user", method: "GET"))
+        }
+
+        /**
+         List all User Types
+         
+         - parameter completion: Completion block
+         */
+        public func listUserTypes(completion: @escaping (Result<OktaResponse<[UserType]>, Error>) -> Void) {
+            do {
+                send(try request(to: "/api/v1/meta/types/user", method: "GET"), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
         /**
@@ -78,6 +137,23 @@ public extension OktaClient {
         }
 
         /**
+         Replace a User Type
+         
+         - parameter typeId: (path)  
+         - parameter userType: (body)  
+         - parameter completion: Completion block
+         */
+        public func replaceUserType(typeId: String, userType: UserType, completion: @escaping (Result<OktaResponse<UserType>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/meta/types/user/{typeId}".expanded(using: [
+                        "typeId": typeId
+                    ]), method: "PUT", body: userType), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
+        /**
          Update a User Type
          
          - parameter typeId: (path)  
@@ -87,6 +163,23 @@ public extension OktaClient {
             try await send(try requestWithBody(to: "/api/v1/meta/types/user/{typeId}".expanded(using: [
                     "typeId": typeId
                 ]), method: "POST", body: userType))
+        }
+
+        /**
+         Update a User Type
+         
+         - parameter typeId: (path)  
+         - parameter userType: (body)  
+         - parameter completion: Completion block
+         */
+        public func updateUserType(typeId: String, userType: UserType, completion: @escaping (Result<OktaResponse<UserType>, Error>) -> Void) {
+            do {
+                send(try requestWithBody(to: "/api/v1/meta/types/user/{typeId}".expanded(using: [
+                        "typeId": typeId
+                    ]), method: "POST", body: userType), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
         }
 
     }

--- a/Sources/OktaSdk/OktaClient+Network.swift
+++ b/Sources/OktaSdk/OktaClient+Network.swift
@@ -154,6 +154,23 @@ extension OktaClientAPI {
         return result
     }
 
+    func send<T: Decodable>(_ request: URLRequest, completion: @escaping (Result<OktaResponse<T>, Error>) -> Void) {
+         context.session.dataTask(with: request) { data, response, error in
+             guard let data = data,
+                   let response = response
+             else {
+                 completion(.failure(error ?? OktaClientError.unknown))
+                 return
+             }
+
+             do {
+                 try completion(.success(self.validate(data, response)))
+             } catch {
+                 completion(.failure(error))
+             }
+         }.resume()
+     }
+
     func send<T: Decodable>(_ request: URLRequest) async throws -> OktaResponse<T> {
         let (data, response) = try await context.session.data(for: request)
         return try validate(data, response)

--- a/openapi-template/api.mustache
+++ b/openapi-template/api.mustache
@@ -67,6 +67,36 @@ public extension OktaClient {
                 ]{{/hasHeaderParams}}{{#bodyParam}}, body: {{paramName}}{{/bodyParam}}))
         }
 
+        /**
+         {{#summary}}
+         {{{summary}}}
+         {{/summary}}{{#allParams}}
+         - parameter {{paramName}}: ({{#isFormParam}}form{{/isFormParam}}{{#isQueryParam}}query{{/isQueryParam}}{{#isPathParam}}path{{/isPathParam}}{{#isHeaderParam}}header{{/isHeaderParam}}{{#isBodyParam}}body{{/isBodyParam}}) {{description}} {{^required}}(optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}{{/allParams}}
+         - parameter completion: Completion block
+         */
+        {{#isDeprecated}}
+        @available(*, deprecated, message: "This operation is deprecated.")
+        {{/isDeprecated}}
+        public func {{operationId}}({{#allParams}}{{paramName}}: {{#isEnum}}{{#isContainer}}{{{dataType}}}{{/isContainer}}{{^isContainer}}{{{datatypeWithEnum}}}_{{operationId}}{{/isContainer}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}{{^required}}? = nil{{/required}}, {{/allParams}}completion: @escaping (Result<OktaResponse<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Empty{{/returnType}}>, Error>) -> Void) {
+            do {
+                send(try request{{#bodyParam}}WithBody{{/bodyParam}}(to: "{{{path}}}"{{#hasPathParams}}.expanded(using: [
+                    {{#pathParams}}
+                        "{{paramName}}": {{paramName}}{{^-last}}, {{/-last}}
+                    {{/pathParams}}
+                    ]){{/hasPathParams}}, method: "{{httpMethod}}"{{#hasQueryParams}}, query: [
+                        {{#queryParams}}
+                        "{{paramName}}": {{paramName}}{{^-last}}, {{/-last}}
+                        {{/queryParams}}
+                    ]{{/hasQueryParams}}{{#hasHeaderParams}}, headers: [
+                        {{#headerParams}}
+                        "{{paramName}}": {{paramName}}?.stringValue{{^-last}}, {{/-last}}
+                        {{/headerParams}}
+                    ]{{/hasHeaderParams}}{{#bodyParam}}, body: {{paramName}}{{/bodyParam}}), completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+
 {{/operation}}
     }
 }


### PR DESCRIPTION
The okta-idx-swift UI tests previously used completion blocks, and XCTest's poor support for Swift Concurrency means it's easier to simply reintroduce these completion-handler methods.