### PR TITLE
chore: Migrate CircleCI to M4 Pro and add CODEOWNERS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
   apple-ci-arm-medium:
     macos:
       xcode: 14.3.1
-    resource_class: macos.m1.medium.gen1
+    resource_class: m4pro.medium
 
 jobs:
   setup:

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+# CODEOWNERS file for okta-sdk-swift
+# These owners will be the default owners for everything in the repo
+* @aniket-okta @dhiwakar-okta @manmohan-shaw-okta


### PR DESCRIPTION
## Changes
- Migrated CircleCI resource class from deprecated `macos.m1.medium.gen1` to `macos.m4pro.medium`
- Added CODEOWNERS file with team ownership

## Context
CircleCI is deprecating M1/M2 resource classes in February 2026. This update migrates to the faster M4 Pro runners to avoid service disruption.

Fixes: [OKTA-1044958](https://oktainc.atlassian.net/browse/OKTA-1044958)